### PR TITLE
Fix missing service account handling

### DIFF
--- a/backend/app/services/sheets_service.py
+++ b/backend/app/services/sheets_service.py
@@ -22,7 +22,10 @@ SERVICE_ACCOUNT_FILE_ENV = os.getenv("GOOGLE_SERVICE_ACCOUNT_FILE")
 DEFAULT_SPREADSHEET_ID = os.getenv("GOOGLE_SHEET_ID")  # Fallback if no config in DB
 
 # Path resolution logic to handle both Windows and Linux/Docker paths
-def resolve_service_account_path(path: str) -> str:
+def resolve_service_account_path(path: Optional[str]) -> Optional[str]:
+    """Safely resolve a service account file path."""
+    if not path:
+        return None
     # If the path exists as-is, use it
     if os.path.exists(path):
         return path

--- a/setup_codex.py
+++ b/setup_codex.py
@@ -13,11 +13,22 @@ sys.path.append(os.path.abspath("backend"))
 from dotenv import load_dotenv
 load_dotenv()
 
-# Test Google Sheets service
-from app.services.sheets_service import get_sheets_service
+missing_creds = not (
+    os.getenv("GOOGLE_SERVICE_ACCOUNT_FILE")
+    or (os.getenv("B64_PART_1") and os.getenv("B64_PART_2"))
+)
 
-try:
-    sheets = get_sheets_service()
-    print("✅ Google Sheets API initialized successfully.")
-except Exception as e:
-    print("❌ Failed to initialize Google Sheets API:", e)
+if missing_creds:
+    print(
+        "⚠️  Google service account credentials not found. "
+        "Set GOOGLE_SERVICE_ACCOUNT_FILE or B64_PART_1 and B64_PART_2 in your .env"
+    )
+else:
+    # Test Google Sheets service only if credentials are available
+    from app.services.sheets_service import get_sheets_service
+
+    try:
+        sheets = get_sheets_service()
+        print("✅ Google Sheets API initialized successfully.")
+    except Exception as e:
+        print("❌ Failed to initialize Google Sheets API:", e)


### PR DESCRIPTION
## Summary
- avoid TypeError when `GOOGLE_SERVICE_ACCOUNT_FILE` isn't set
- warn in `setup_codex.py` when Google credentials are missing

## Testing
- `python setup_codex.py`
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6840fd8590488323926ae2b584ffb119