### PR TITLE
Add team comparison and re-rank feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,106 +1,125 @@
 # Changelog
 
+## 2025-06-05
+
+- Added team comparison modal with GPT-powered re-ranking
+- New `/api/picklist/compare-teams` endpoint
+
 ## 2025-05-20
-* Documentation refreshed with database model overview
-* Added Docker quickstart instructions to README
-* Updated requirements to latest versions
-* New Architecture section for database models
+
+- Documentation refreshed with database model overview
+- Added Docker quickstart instructions to README
+- Updated requirements to latest versions
+- New Architecture section for database models
 
 ## 2025-05-19
-* Implemented real-time progress tracking for picklist generation
-* Added ProgressTracker component with percentage completion and time estimates
-* Enhanced picklist generator service with threading for non-blocking API calls
-* Updated frontend to show progress immediately when generation starts
-* Fixed issue where progress bar wouldn't update during API calls
-* Added progressive updates during long-running GPT operations
+
+- Implemented real-time progress tracking for picklist generation
+- Added ProgressTracker component with percentage completion and time estimates
+- Enhanced picklist generator service with threading for non-blocking API calls
+- Updated frontend to show progress immediately when generation starts
+- Fixed issue where progress bar wouldn't update during API calls
+- Added progressive updates during long-running GPT operations
 
 ## 2025-05-16
-* Enhanced database migration system for locked picklists
-* Added excluded_teams and strategy_prompts columns to LockedPicklist table
-* Created comprehensive migration script with logging and error handling
-* Updated MIGRATION.md documentation with detailed instructions
-* Improved event archival to include all picklist generation context
+
+- Enhanced database migration system for locked picklists
+- Added excluded_teams and strategy_prompts columns to LockedPicklist table
+- Created comprehensive migration script with logging and error handling
+- Updated MIGRATION.md documentation with detailed instructions
+- Improved event archival to include all picklist generation context
 
 ## 2025-05-12
-* Implemented event archival system for preserving historical data
-* Created archive service and API endpoints for event backup
-* Added EventArchiveManager component for managing archived events
-* Enhanced unified dataset with event metadata and team lists
-* Integrated progress tracking for archive operations
+
+- Implemented event archival system for preserving historical data
+- Created archive service and API endpoints for event backup
+- Added EventArchiveManager component for managing archived events
+- Enhanced unified dataset with event metadata and team lists
+- Integrated progress tracking for archive operations
 
 ## 2025-05-09
-* Implemented Live Alliance Selection feature with database persistence
-* Added Lock/Unlock functionality for picklists to prevent edits after finalization
-* Created team grid display for Alliance Selection sorted by picklist ranking
-* Added Alliance Board display showing current alliance selections
-* Implemented proper handling of Round 3 backup picks for World Championship events
-* Added team status tracking (captain, picked, declined) in alliance selection
-* Ensured teams that declined can still be selected as captains (per FRC rules)
-* Fixed navigation between Alliance Selection and Picklist to prevent auto-regeneration
-* Added SQLAlchemy models and API endpoints for alliance selection tracking
+
+- Implemented Live Alliance Selection feature with database persistence
+- Added Lock/Unlock functionality for picklists to prevent edits after finalization
+- Created team grid display for Alliance Selection sorted by picklist ranking
+- Added Alliance Board display showing current alliance selections
+- Implemented proper handling of Round 3 backup picks for World Championship events
+- Added team status tracking (captain, picked, declined) in alliance selection
+- Ensured teams that declined can still be selected as captains (per FRC rules)
+- Fixed navigation between Alliance Selection and Picklist to prevent auto-regeneration
+- Added SQLAlchemy models and API endpoints for alliance selection tracking
 
 ## 2025-05-08
-* Implemented ultra-compact JSON format for GPT responses (75% token reduction)
-* Added comprehensive progress tracking during picklist generation
-* Enhanced error recovery with robust JSON parsing and fallback mechanisms
-* Added visual indicators for auto-added teams in picklists
-* Implemented request deduplication to prevent redundant API calls
-* Created debug logging system with dedicated UI viewer
+
+- Implemented ultra-compact JSON format for GPT responses (75% token reduction)
+- Added comprehensive progress tracking during picklist generation
+- Enhanced error recovery with robust JSON parsing and fallback mechanisms
+- Added visual indicators for auto-added teams in picklists
+- Implemented request deduplication to prevent redundant API calls
+- Created debug logging system with dedicated UI viewer
 
 ## 2025-05-07
-* Added superscouting metrics to picklist generation for more qualitative robot assessment
-* Enhanced strategy parsing to better recognize robot capabilities in natural language descriptions
-* Implemented realistic alliance selection logic (excludes alliance captains for 2nd/3rd picks)
-* Added dataset retrieval endpoint with support for both path and event_key loading
-* Improved error handling with fallback dataset mechanism for offline/error scenarios
-* Added detailed UI information showing which teams are excluded during picklist generation
-* Fixed issues with Windows path encoding in dataset loading
+
+- Added superscouting metrics to picklist generation for more qualitative robot assessment
+- Enhanced strategy parsing to better recognize robot capabilities in natural language descriptions
+- Implemented realistic alliance selection logic (excludes alliance captains for 2nd/3rd picks)
+- Added dataset retrieval endpoint with support for both path and event_key loading
+- Improved error handling with fallback dataset mechanism for offline/error scenarios
+- Added detailed UI information showing which teams are excluded during picklist generation
+- Fixed issues with Windows path encoding in dataset loading
 
 ## 2025-05-06
-* Switched from chunking to one-shot picklist generation to avoid duplication
-* Implemented two-phase ranking with automatic fallback for missing teams
-* Added LocalStorage persistence for picklist data across page navigation
-* Created PicklistNew page with enhanced UI for picklist building
-* Added pagination controls for picklist viewing with configurable page size
-* Implemented confirmation dialogs for data clearing operations
+
+- Switched from chunking to one-shot picklist generation to avoid duplication
+- Implemented two-phase ranking with automatic fallback for missing teams
+- Added LocalStorage persistence for picklist data across page navigation
+- Created PicklistNew page with enhanced UI for picklist building
+- Added pagination controls for picklist viewing with configurable page size
+- Implemented confirmation dialogs for data clearing operations
 
 ## 2025‑05‑01
-* Refactored field selection approach to use direct Google Sheets headers instead of GPT-derived fields
-* Added unified dataset endpoint for building comprehensive event datasets
-* Implemented enhanced validation with outlier detection using statistical methods
-* Added Workflow component to guide users through application flow
-* Built Validation page for identifying and fixing missing and outlier data
-* Updated picklist generation to incorporate game strategy insights when available
-* Added natural language parsing for strategy descriptions
+
+- Refactored field selection approach to use direct Google Sheets headers instead of GPT-derived fields
+- Added unified dataset endpoint for building comprehensive event datasets
+- Implemented enhanced validation with outlier detection using statistical methods
+- Added Workflow component to guide users through application flow
+- Built Validation page for identifying and fixing missing and outlier data
+- Updated picklist generation to incorporate game strategy insights when available
+- Added natural language parsing for strategy descriptions
 
 ## 2025‑04‑29
-* Added learning setup endpoint and service
-* Implemented year‑mapped `statbotics_client` with default fallback
-* Fixed path resolution for config files (absolute from `__file__`)
-* Added `python-multipart` dependency for form uploads
-* Created sheet configuration management system
+
+- Added learning setup endpoint and service
+- Implemented year‑mapped `statbotics_client` with default fallback
+- Fixed path resolution for config files (absolute from `__file__`)
+- Added `python-multipart` dependency for form uploads
+- Created sheet configuration management system
 
 ## 2025‑04‑28
-* Superscouting validation bug fixed (integer team keys)
-* Defined modular roadmap: Learning → Validation → Pick‑List → Alliance
-* Patched Superscouting validator to use per-team check
-* Added expected_matches into Unified Event Dataset during build
-* Enhanced schema mapping with user correction wizard
+
+- Superscouting validation bug fixed (integer team keys)
+- Defined modular roadmap: Learning → Validation → Pick‑List → Alliance
+- Patched Superscouting validator to use per-team check
+- Added expected_matches into Unified Event Dataset during build
+- Enhanced schema mapping with user correction wizard
 
 ## 2025‑04‑27
-* FastAPI skeleton, CORS, health route
-* Initial data validation service and unified dataset builder (legacy)
-* Built unified_event_data_service to merge scouting, superscouting, TBA, and Statbotics
-* Built data_validation_service to check completeness
-* Added TypeScript to frontend for better type safety
+
+- FastAPI skeleton, CORS, health route
+- Initial data validation service and unified dataset builder (legacy)
+- Built unified_event_data_service to merge scouting, superscouting, TBA, and Statbotics
+- Built data_validation_service to check completeness
+- Added TypeScript to frontend for better type safety
 
 ## 2025‑04‑26
-* Integrated Google Sheets service account read/write
-* Created auto-schema mapping wizard (schema_2025.json, schema_superscout_2025.json)
-* Integrated The Blue Alliance API v3 client
-* Added field categorization system for metrics
+
+- Integrated Google Sheets service account read/write
+- Created auto-schema mapping wizard (schema_2025.json, schema_superscout_2025.json)
+- Integrated The Blue Alliance API v3 client
+- Added field categorization system for metrics
 
 ## 2025‑04‑25
-* Initial FastAPI and React project bootstrap
-* Created basic project structure and documentation
-* Set up development environment and dependencies
+
+- Initial FastAPI and React project bootstrap
+- Created basic project structure and documentation
+- Set up development environment and dependencies

--- a/backend/app/api/team_comparison.py
+++ b/backend/app/api/team_comparison.py
@@ -1,0 +1,42 @@
+"""API endpoint for comparing teams and re-ranking them."""
+
+from typing import List, Optional, Dict, Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from app.services.team_comparison_service import TeamComparisonService
+
+router = APIRouter(prefix="/api/picklist", tags=["Picklist"])
+
+
+class MetricPriority(BaseModel):
+    id: str
+    weight: float = Field(1.0, ge=0.5, le=3.0)
+    reason: Optional[str] = None
+
+
+class CompareTeamsRequest(BaseModel):
+    unified_dataset_path: str
+    team_numbers: List[int]
+    your_team_number: int
+    pick_position: str = Field(..., regex="^(first|second|third)$")
+    priorities: List[MetricPriority]
+    question: Optional[str] = None
+
+
+@router.post("/compare-teams")
+async def compare_teams(request: CompareTeamsRequest) -> Dict[str, Any]:
+    try:
+        service = TeamComparisonService(request.unified_dataset_path)
+        priorities = [p.model_dump() for p in request.priorities]
+        result = await service.compare_teams(
+            team_numbers=request.team_numbers,
+            your_team_number=request.your_team_number,
+            pick_position=request.pick_position,
+            priorities=priorities,
+            question=request.question,
+        )
+        return {"status": "success", **result}
+    except Exception as e:  # pragma: no cover - simple passthrough
+        raise HTTPException(status_code=500, detail=f"Error comparing teams: {e}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -47,6 +47,7 @@ from app.api import alliance_selection  # Import alliance selection API
 from app.api import archive  # Import event archiving API
 from app.api import sheet_config  # Import sheet configuration API
 from app.api import manuals as manuals_router  # Import the new manuals router
+from app.api import team_comparison  # New team comparison API
 
 app = FastAPI(title="FRC Scouting Assistant", version="0.1.0")
 
@@ -95,6 +96,7 @@ app.include_router(unified_dataset.router, prefix="/api/unified")
 app.include_router(field_selection.router)  # Add the field selection router
 app.include_router(picklist_analysis.router, prefix="/api")
 app.include_router(picklist_generator.router)
+app.include_router(team_comparison.router)
 app.include_router(test_schema_superscout.router)  # Add the test endpoint
 app.include_router(test_enhanced_parser.router)  # Add the enhanced parser test
 app.include_router(progress.router, prefix="/api")  # Add the progress tracking API

--- a/backend/app/services/team_comparison_service.py
+++ b/backend/app/services/team_comparison_service.py
@@ -1,0 +1,78 @@
+"""Service for comparing a small set of teams using GPT."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from app.services.picklist_generator_service import PicklistGeneratorService
+
+load_dotenv()
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+GPT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
+
+
+class TeamComparisonService:
+    """Compare up to three teams and return a ranking and summary."""
+
+    def __init__(self, unified_dataset_path: str) -> None:
+        self.generator = PicklistGeneratorService(unified_dataset_path)
+
+    async def compare_teams(
+        self,
+        team_numbers: List[int],
+        your_team_number: int,
+        pick_position: str,
+        priorities: List[Dict[str, Any]],
+        question: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if not team_numbers or len(team_numbers) < 2:
+            raise ValueError("At least two teams must be provided")
+
+        teams_data_all = self.generator._prepare_team_data_for_gpt()
+        teams_data = [t for t in teams_data_all if t["team_number"] in team_numbers]
+        if len(teams_data) != len(team_numbers):
+            found = {t["team_number"] for t in teams_data}
+            missing = [n for n in team_numbers if n not in found]
+            raise ValueError(f"Teams not found in dataset: {missing}")
+
+        teams_data.sort(key=lambda t: team_numbers.index(t["team_number"]))
+        system_prompt = self.generator._create_system_prompt(pick_position, len(teams_data))
+        team_index_map = {i + 1: t["team_number"] for i, t in enumerate(teams_data)}
+        user_prompt = self.generator._create_user_prompt(
+            your_team_number,
+            pick_position,
+            priorities,
+            teams_data,
+            team_numbers,
+            team_index_map,
+        )
+        if question:
+            user_prompt += f"\nQUESTION = {question}\nReturn answer in 'summary' field."
+
+        self.generator._check_token_count(system_prompt, user_prompt)
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+
+        response = client.chat.completions.create(
+            model=GPT_MODEL,
+            messages=messages,
+            temperature=0.2,
+            response_format={"type": "json_object"},
+            max_tokens=2000,
+        )
+        data = json.loads(response.choices[0].message.content)
+        ordered = self.generator._parse_response_with_index_mapping(
+            data, teams_data, team_index_map
+        )
+        return {
+            "ordered_teams": ordered if ordered else teams_data,
+            "summary": data.get("summary", ""),
+        }

--- a/frontend/src/components/PicklistGenerator.tsx
+++ b/frontend/src/components/PicklistGenerator.tsx
@@ -1,6 +1,7 @@
 // frontend/src/components/PicklistGenerator.tsx
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
+import TeamComparisonModal from "./TeamComparisonModal";
 
 interface Team {
   team_number: number;
@@ -63,8 +64,13 @@ interface MissingTeamsResult {
 interface PicklistGeneratorProps {
   datasetPath: string;
   yourTeamNumber: number;
-  pickPosition: 'first' | 'second' | 'third';
+  pickPosition: "first" | "second" | "third";
   priorities: MetricPriority[];
+  allPriorities?: {
+    first: MetricPriority[];
+    second: MetricPriority[];
+    third: MetricPriority[];
+  };
   excludeTeams?: number[];
   onPicklistGenerated?: (result: PicklistResult) => void;
   initialPicklist?: Team[]; // Add prop for initial picklist data
@@ -74,24 +80,27 @@ interface PicklistGeneratorProps {
 }
 
 // Progress indicator component for estimated time (non-batch processing)
-const ProgressIndicator: React.FC<{ estimatedTime: number; teamCount: number }> = ({ estimatedTime, teamCount }) => {
+const ProgressIndicator: React.FC<{
+  estimatedTime: number;
+  teamCount: number;
+}> = ({ estimatedTime, teamCount }) => {
   const [elapsedTime, setElapsedTime] = useState<number>(0);
   const [progress, setProgress] = useState<number>(0);
-  
+
   // Set up timer
   useEffect(() => {
     const timer = setInterval(() => {
-      setElapsedTime(prev => {
+      setElapsedTime((prev) => {
         const newTime = prev + 0.1;
         // Update progress
         setProgress(Math.min((newTime / estimatedTime) * 100, 99));
         return newTime;
       });
     }, 100); // Update every 100ms
-    
+
     return () => clearInterval(timer);
   }, [estimatedTime]);
-  
+
   return (
     <div className="flex flex-col items-center w-full max-w-lg mx-auto my-8 px-4">
       <div className="text-center mb-4 space-y-2">
@@ -105,27 +114,30 @@ const ProgressIndicator: React.FC<{ estimatedTime: number; teamCount: number }> 
           Time elapsed: {elapsedTime.toFixed(1)} seconds
         </p>
       </div>
-      
+
       <div className="w-full bg-gray-200 rounded-full h-4 mb-2">
-        <div 
+        <div
           className="bg-blue-600 h-4 rounded-full transition-all duration-100 ease-out"
           style={{ width: `${progress}%` }}
         ></div>
       </div>
-      
+
       <p className="text-sm text-gray-500">
-        {progress < 30 ? 'Starting...' : 
-         progress < 60 ? 'Processing team data...' : 
-         progress < 90 ? 'Generating rankings...' : 
-         'Finalizing picklist...'}
+        {progress < 30
+          ? "Starting..."
+          : progress < 60
+            ? "Processing team data..."
+            : progress < 90
+              ? "Generating rankings..."
+              : "Finalizing picklist..."}
       </p>
     </div>
   );
 };
 
 // Batch progress component
-const BatchProgressIndicator: React.FC<{ 
-  batchInfo: BatchProcessing; 
+const BatchProgressIndicator: React.FC<{
+  batchInfo: BatchProcessing;
   elapsedTime: number;
 }> = ({ batchInfo, elapsedTime }) => {
   return (
@@ -135,31 +147,39 @@ const BatchProgressIndicator: React.FC<{
           Generating Picklist in Batches
         </h3>
         <p className="text-gray-600">
-          Processing teams in batches for higher quality rankings (updates every 5 seconds)
+          Processing teams in batches for higher quality rankings (updates every
+          5 seconds)
         </p>
         <p className="text-gray-600">
           Time elapsed: {elapsedTime.toFixed(1)} seconds
         </p>
       </div>
-      
+
       <div className="w-full bg-gray-200 rounded-full h-4 mb-2">
-        <div 
+        <div
           className="bg-blue-600 h-4 rounded-full transition-all duration-100 ease-out"
           style={{ width: `${batchInfo.progress_percentage}%` }}
         ></div>
       </div>
-      
+
       <div className="flex justify-between w-full text-sm text-gray-600 mt-1 mb-3">
-        <span>Processing batch {batchInfo.current_batch} of {batchInfo.total_batches}</span>
+        <span>
+          Processing batch {batchInfo.current_batch} of{" "}
+          {batchInfo.total_batches}
+        </span>
         <span>{batchInfo.progress_percentage}% complete</span>
       </div>
-      
+
       <p className="text-sm text-gray-500">
-        {batchInfo.progress_percentage === 0 ? 'Starting batch processing...' : 
-         batchInfo.progress_percentage < 30 ? 'Processing first batches...' : 
-         batchInfo.progress_percentage < 70 ? 'Ranking teams with reference teams...' : 
-         batchInfo.progress_percentage < 95 ? 'Processing final batches...' : 
-         'Combining results...'}
+        {batchInfo.progress_percentage === 0
+          ? "Starting batch processing..."
+          : batchInfo.progress_percentage < 30
+            ? "Processing first batches..."
+            : batchInfo.progress_percentage < 70
+              ? "Ranking teams with reference teams..."
+              : batchInfo.progress_percentage < 95
+                ? "Processing final batches..."
+                : "Combining results..."}
       </p>
     </div>
   );
@@ -177,7 +197,8 @@ const MissingTeamsModal: React.FC<{
       <div className="bg-white rounded-lg shadow-xl p-6 max-w-md w-full">
         <h3 className="text-xl font-bold mb-4">Auto-Added Teams Detected</h3>
         <p className="mb-6">
-          {missingTeamCount} teams have been automatically added with estimated scores. Would you like to get more accurate rankings for these teams?
+          {missingTeamCount} teams have been automatically added with estimated
+          scores. Would you like to get more accurate rankings for these teams?
         </p>
         <div className="flex justify-end space-x-3">
           <button
@@ -198,7 +219,7 @@ const MissingTeamsModal: React.FC<{
                 Ranking...
               </>
             ) : (
-              'Get Accurate Rankings'
+              "Get Accurate Rankings"
             )}
           </button>
         </div>
@@ -212,12 +233,13 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
   yourTeamNumber,
   pickPosition,
   priorities,
+  allPriorities,
   excludeTeams = [],
   onPicklistGenerated,
   initialPicklist = [],
   onExcludeTeam,
   isLocked = false,
-  onPicklistCleared
+  onPicklistCleared,
 }) => {
   const [picklist, setPicklist] = useState<Team[]>(initialPicklist);
   const [analysis, setAnalysis] = useState<PicklistAnalysis | null>(null);
@@ -227,161 +249,172 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [showAnalysis, setShowAnalysis] = useState<boolean>(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  
+
+  // Team comparison state
+  const [selectedTeams, setSelectedTeams] = useState<number[]>([]);
+  const [showComparison, setShowComparison] = useState<boolean>(false);
+
   // Missing teams state
   const [missingTeamNumbers, setMissingTeamNumbers] = useState<number[]>([]);
-  const [showMissingTeamsModal, setShowMissingTeamsModal] = useState<boolean>(false);
-  const [isRankingMissingTeams, setIsRankingMissingTeams] = useState<boolean>(false);
-  
+  const [showMissingTeamsModal, setShowMissingTeamsModal] =
+    useState<boolean>(false);
+  const [isRankingMissingTeams, setIsRankingMissingTeams] =
+    useState<boolean>(false);
+
   // Pagination state
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [teamsPerPage, setTeamsPerPage] = useState<number>(10);
   const [totalPages, setTotalPages] = useState<number>(1);
-  
+
   // Batch processing state
-  const [batchProcessingActive, setBatchProcessingActive] = useState<boolean>(false);
-  const [batchProcessingInfo, setBatchProcessingInfo] = useState<BatchProcessing | null>(null);
+  const [batchProcessingActive, setBatchProcessingActive] =
+    useState<boolean>(false);
+  const [batchProcessingInfo, setBatchProcessingInfo] =
+    useState<BatchProcessing | null>(null);
   const [pollingCacheKey, setPollingCacheKey] = useState<string | null>(null);
   const [elapsedTime, setElapsedTime] = useState<number>(0);
-  
+
   // Batching control - persist in localStorage
   const [useBatching, setUseBatching] = useState<boolean>(() => {
-    const saved = localStorage.getItem('useBatching');
+    const saved = localStorage.getItem("useBatching");
     return saved !== null ? JSON.parse(saved) : true;
   });
-  
+
   // Save useBatching to localStorage whenever it changes
   useEffect(() => {
-    localStorage.setItem('useBatching', JSON.stringify(useBatching));
+    localStorage.setItem("useBatching", JSON.stringify(useBatching));
   }, [useBatching]);
-  
+
   useEffect(() => {
     // Log when dependencies change
-    console.log("PicklistGenerator dependencies changed:", { 
-      pickPosition, 
+    console.log("PicklistGenerator dependencies changed:", {
+      pickPosition,
       prioritiesCount: priorities.length,
-      excludeTeamsCount: excludeTeams?.length
+      excludeTeamsCount: excludeTeams?.length,
     });
-    
+
     if (excludeTeams && excludeTeams.length > 0) {
       console.log("Teams to exclude:", excludeTeams);
     }
-    
+
     // If we have an initial picklist, use it
     if (initialPicklist && initialPicklist.length > 0) {
       setPicklist(initialPicklist);
       // Calculate total pages
       setTotalPages(Math.ceil(initialPicklist.length / teamsPerPage));
     }
-    
-    /* 
+
+    /*
      * IMPORTANT NOTE ON AUTOMATIC REGENERATION:
      * We deliberately removed the automatic generatePicklist() call that was here previously.
      * This prevents unwanted regeneration when navigating between pages (especially when
      * returning from Alliance Selection back to Picklist).
-     * 
+     *
      * Rankings will ONLY be generated when the user explicitly clicks the "Generate Rankings" button.
      * This ensures the user experience is predictable and prevents unexpected API calls.
-     * 
+     *
      * This change was made on 2025-05-09 to improve navigation between the
      * Picklist and Alliance Selection pages.
      */
-    
+
     // Reset to page 1 when dependencies change
     setCurrentPage(1);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasetPath, yourTeamNumber, pickPosition]); 
-  
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasetPath, yourTeamNumber, pickPosition]);
+
   // Add a separate effect to handle deep changes to priorities and excludeTeams
   useEffect(() => {
     // This effect will only run when priorities or excludeTeams change in a way that affects the actual data
     // This prevents the problem of JSON.stringify creating a new string on every render
     console.log("Priorities or exclusions changed significantly");
-    
+
     // We've removed the automatic regeneration here too
     // The user must explicitly click "Generate Rankings" to trigger regeneration
     // This prevents unexpected regeneration when navigating between tabs
-    
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     // Use the length as a proxy for deep changes
-    priorities.length, 
+    priorities.length,
     excludeTeams?.length,
     // We need datasetPath and yourTeamNumber for the check inside
     datasetPath,
-    yourTeamNumber
+    yourTeamNumber,
   ]);
-  
+
   // Update totalPages when teamsPerPage changes
   useEffect(() => {
     setTotalPages(Math.ceil(picklist.length / teamsPerPage));
   }, [picklist.length, teamsPerPage]);
-  
+
   // Elapsed time counter for batch processing
   useEffect(() => {
     let timer: ReturnType<typeof setInterval> | null = null;
-    
+
     if (batchProcessingActive) {
       // Start a timer that updates every 100ms
       timer = setInterval(() => {
-        setElapsedTime(prev => prev + 0.1);
+        setElapsedTime((prev) => prev + 0.1);
       }, 100);
     } else {
       // Reset elapsed time when batch processing stops
       setElapsedTime(0);
     }
-    
+
     return () => {
       if (timer) clearInterval(timer);
     };
   }, [batchProcessingActive]);
-  
+
   // Polling effect for batch processing status
   useEffect(() => {
     let pollingInterval: ReturnType<typeof setInterval> | null = null;
-    
+
     if (batchProcessingActive && pollingCacheKey) {
       // Poll every 5 seconds to reduce OPTIONS requests
       pollingInterval = setInterval(async () => {
         try {
-          const response = await fetch('http://localhost:8000/api/picklist/generate/status', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ cache_key: pollingCacheKey })
-          });
-          
+          const response = await fetch(
+            "http://localhost:8000/api/picklist/generate/status",
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ cache_key: pollingCacheKey }),
+            },
+          );
+
           if (!response.ok) {
-            console.error('Error polling batch status:', response.status);
+            console.error("Error polling batch status:", response.status);
             return;
           }
-          
+
           const data = await response.json();
-          
+
           // Update batch processing info
           if (data.batch_processing) {
             setBatchProcessingInfo(data.batch_processing);
-            
+
             // If processing is complete, stop polling and process the final result
             if (data.batch_processing.processing_complete) {
               setBatchProcessingActive(false);
               if (pollingInterval) clearInterval(pollingInterval);
-              
+
               // Process the picklist data if it's included with the completion response
               if (data.picklist) {
-                console.log('Processing completed picklist data:', data);
-                
+                console.log("Processing completed picklist data:", data);
+
                 // Process the picklist data
                 setPicklist(data.picklist);
                 if (data.analysis) setAnalysis(data.analysis);
-                
+
                 // Reset batch processing state
                 setBatchProcessingInfo(null);
                 setPollingCacheKey(null);
-                
+
                 // Reset to page 1
                 setCurrentPage(1);
                 setTotalPages(Math.ceil(data.picklist.length / teamsPerPage));
-                
+
                 // Call the callback if provided
                 if (onPicklistGenerated) {
                   onPicklistGenerated(data);
@@ -393,58 +426,61 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
             }
           }
         } catch (err) {
-          console.error('Error polling batch status:', err);
+          console.error("Error polling batch status:", err);
         }
       }, 5000); // Increased from 2000ms to 5000ms to reduce OPTIONS requests
     }
-    
+
     return () => {
       if (pollingInterval) clearInterval(pollingInterval);
     };
   }, [batchProcessingActive, pollingCacheKey]);
-  
+
   // Function to fetch the completed picklist
   const fetchCompletedPicklist = async () => {
     if (!pollingCacheKey) return;
-    
+
     try {
       // Fetch the completed picklist using the cache key
-      const response = await fetch('http://localhost:8000/api/picklist/generate/status', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ cache_key: pollingCacheKey })
-      });
-      
+      const response = await fetch(
+        "http://localhost:8000/api/picklist/generate/status",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cache_key: pollingCacheKey }),
+        },
+      );
+
       if (!response.ok) {
-        throw new Error('Failed to fetch completed picklist');
+        throw new Error("Failed to fetch completed picklist");
       }
-      
+
       const data = await response.json();
-      
+
       // If we have a complete result with picklist data, process it
-      if (data.status === 'success' && data.picklist) {
+      if (data.status === "success" && data.picklist) {
         // Process the picklist data
         setPicklist(data.picklist);
         if (data.analysis) setAnalysis(data.analysis);
-        
+
         // Reset batch processing state
         setBatchProcessingActive(false);
         setBatchProcessingInfo(null);
         setPollingCacheKey(null);
-        
+
         // Reset to page 1
         setCurrentPage(1);
         setTotalPages(Math.ceil(data.picklist.length / teamsPerPage));
-        
+
         // Call the callback if provided
         if (onPicklistGenerated) {
           onPicklistGenerated(data);
         }
       }
     } catch (err) {
-      console.error('Error fetching completed picklist:', err);
-      setError('Failed to fetch the completed picklist');
-      
+      console.error("Error fetching completed picklist:", err);
+      setError("Failed to fetch the completed picklist");
+
       // Reset batch processing state
       setBatchProcessingActive(false);
       setBatchProcessingInfo(null);
@@ -453,69 +489,72 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
       setIsLoading(false);
     }
   };
-  
+
   const clearPicklist = async () => {
     // Clear the current picklist state
     setPicklist([]);
     setAnalysis(null);
-    
+
     // Clear any cache on the backend
     try {
-      const response = await fetch('http://localhost:8000/api/picklist/clear-cache', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({})
-      });
-      
+      const response = await fetch(
+        "http://localhost:8000/api/picklist/clear-cache",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      );
+
       if (!response.ok) {
-        console.error('Failed to clear backend cache');
+        console.error("Failed to clear backend cache");
       } else {
         const result = await response.json();
-        console.log('Cache cleared:', result.message);
+        console.log("Cache cleared:", result.message);
       }
     } catch (error) {
-      console.error('Error clearing cache:', error);
+      console.error("Error clearing cache:", error);
     }
-    
+
     // Reset other states
     setError(null);
-    setSuccessMessage('Picklist cleared successfully');
-    
+    setSuccessMessage("Picklist cleared successfully");
+
     // Reset pagination
     setCurrentPage(1);
     setTotalPages(1);
-    
+
     // Reset batch processing state
     setBatchProcessingActive(false);
     setBatchProcessingInfo(null);
     setPollingCacheKey(null);
     setElapsedTime(0);
-    
+
     // Call the parent component's callback to clear its state
     if (onPicklistCleared) {
       onPicklistCleared();
     }
   };
-  
+
   const generatePicklist = async () => {
     if (!datasetPath || !yourTeamNumber || !priorities.length) {
-      setError('Missing required inputs for picklist generation');
+      setError("Missing required inputs for picklist generation");
       return;
     }
-    
+
     setIsLoading(true);
     setError(null);
-    
+
     // Reset batch processing state
     setBatchProcessingActive(false);
     setBatchProcessingInfo(null);
     setPollingCacheKey(null);
-    
+
     // Calculate estimated time - approximate from team count
     const teamsToRank = excludeTeams ? 75 - excludeTeams.length : 75;
     const estimatedSeconds = teamsToRank * 0.9; // ~0.9 seconds per team
     setEstimatedTime(estimatedSeconds);
-    
+
     try {
       // Send the priorities as plain JSON objects without any methods or class structures
       const simplePriorities = [];
@@ -523,19 +562,25 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
         simplePriorities.push({
           id: priority.id,
           weight: priority.weight,
-          reason: priority.reason || null
+          reason: priority.reason || null,
         });
       }
-      
+
       // Create a request object with all primitive values
       // Ensure excludeTeams is always an array and log it
       const teamsToExclude = excludeTeams || [];
-      console.log(`Excluding ${teamsToExclude.length} teams for ${pickPosition} pick:`, teamsToExclude);
-      
+      console.log(
+        `Excluding ${teamsToExclude.length} teams for ${pickPosition} pick:`,
+        teamsToExclude,
+      );
+
       // Create request body with batching parameters
-      console.log('Current useBatching state before request:', useBatching);
-      console.log('Retrieved from localStorage:', localStorage.getItem('useBatching'));
-      
+      console.log("Current useBatching state before request:", useBatching);
+      console.log(
+        "Retrieved from localStorage:",
+        localStorage.getItem("useBatching"),
+      );
+
       const requestBody = JSON.stringify({
         unified_dataset_path: datasetPath,
         your_team_number: yourTeamNumber,
@@ -545,35 +590,38 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
         use_batching: useBatching,
         batch_size: 20,
         reference_teams_count: 3,
-        reference_selection: "top_middle_bottom"
+        reference_selection: "top_middle_bottom",
       });
-      
-      console.log('Sending request:', requestBody);
-      console.log('useBatching value in request:', useBatching);
-      
-      const response = await fetch('http://localhost:8000/api/picklist/generate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: requestBody
-      });
-      
+
+      console.log("Sending request:", requestBody);
+      console.log("useBatching value in request:", useBatching);
+
+      const response = await fetch(
+        "http://localhost:8000/api/picklist/generate",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: requestBody,
+        },
+      );
+
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.detail || 'Failed to generate picklist');
+        throw new Error(errorData.detail || "Failed to generate picklist");
       }
-      
+
       const data: PicklistResult = await response.json();
-      
+
       // Check if this is a batched result
-      if (data.status === 'success' && data.batched) {
-        console.log('Batch processing initiated', data);
-        
+      if (data.status === "success" && data.batched) {
+        console.log("Batch processing initiated", data);
+
         // If we have a cache key, start polling for updates
         if (data.cache_key) {
           // Start batch processing monitoring
           setBatchProcessingActive(true);
           setPollingCacheKey(data.cache_key);
-          
+
           // Set initial batch processing info if available
           if (data.batch_processing) {
             setBatchProcessingInfo(data.batch_processing);
@@ -583,35 +631,37 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
               total_batches: 0,
               current_batch: 0,
               progress_percentage: 0,
-              processing_complete: false
+              processing_complete: false,
             });
           }
-          
+
           // Don't set picklist until batch processing is complete
           return;
         }
       }
-      
+
       // For non-batched results or immediate completion, process normally
-      if (data.status === 'success') {
+      if (data.status === "success") {
         // Reset batch processing state
         setBatchProcessingActive(false);
         setBatchProcessingInfo(null);
         setPollingCacheKey(null);
-        
+
         setPicklist(data.picklist);
         setAnalysis(data.analysis);
-        
+
         // Reset estimated time
         setEstimatedTime(0);
         setTotalPages(Math.ceil(data.picklist.length / teamsPerPage));
         setCurrentPage(1); // Reset to first page
-        
+
         // Check for missing teams
         if (data.missing_team_numbers && data.missing_team_numbers.length > 0) {
           // Count how many teams are actually auto-added fallbacks in the picklist
-          const autoAddedTeamsCount = data.picklist.filter(team => team.is_fallback).length;
-          
+          const autoAddedTeamsCount = data.picklist.filter(
+            (team) => team.is_fallback,
+          ).length;
+
           if (autoAddedTeamsCount > 0) {
             setMissingTeamNumbers(data.missing_team_numbers);
             setShowMissingTeamsModal(true);
@@ -622,18 +672,18 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
         } else {
           setMissingTeamNumbers([]);
         }
-        
+
         // Call the callback if provided
         if (onPicklistGenerated) {
           onPicklistGenerated(data);
         }
       } else {
-        setError(data.message || 'Error generating picklist');
+        setError(data.message || "Error generating picklist");
       }
     } catch (err: any) {
-      setError(err.message || 'Error connecting to server');
-      console.error('Error generating picklist:', err);
-      
+      setError(err.message || "Error connecting to server");
+      console.error("Error generating picklist:", err);
+
       // Reset batch processing state on error
       setBatchProcessingActive(false);
       setBatchProcessingInfo(null);
@@ -642,70 +692,73 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
       setIsLoading(false);
     }
   };
-  
+
   const updatePicklist = async () => {
     if (!datasetPath || !picklist.length) {
-      setError('No picklist data to update');
+      setError("No picklist data to update");
       return;
     }
-    
+
     setIsLoading(true);
     setError(null);
-    
+
     // Calculate estimated time - approximate from team count
     const teamsToRank = excludeTeams ? 75 - excludeTeams.length : 75;
     const estimatedSeconds = teamsToRank * 0.9; // ~0.9 seconds per team
     setEstimatedTime(estimatedSeconds);
-    
+
     try {
       // Convert picklist to user rankings format
       const userRankings = picklist.map((team, index) => ({
         team_number: team.team_number,
         position: index + 1,
-        nickname: team.nickname
+        nickname: team.nickname,
       }));
-      
-      const response = await fetch('http://localhost:8000/api/picklist/update', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          unified_dataset_path: datasetPath,
-          original_picklist: picklist,
-          user_rankings: userRankings
-        })
-      });
-      
+
+      const response = await fetch(
+        "http://localhost:8000/api/picklist/update",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            unified_dataset_path: datasetPath,
+            original_picklist: picklist,
+            user_rankings: userRankings,
+          }),
+        },
+      );
+
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.detail || 'Failed to update picklist');
+        throw new Error(errorData.detail || "Failed to update picklist");
       }
-      
+
       const data = await response.json();
-      
-      if (data.status === 'success') {
+
+      if (data.status === "success") {
         setPicklist(data.picklist);
         setIsEditing(false);
       } else {
-        setError(data.message || 'Error updating picklist');
+        setError(data.message || "Error updating picklist");
       }
     } catch (err: any) {
-      setError(err.message || 'Error connecting to server');
-      console.error('Error updating picklist:', err);
+      setError(err.message || "Error connecting to server");
+      console.error("Error updating picklist:", err);
     } finally {
       setIsLoading(false);
     }
   };
-  
+
   // Function to rank missing teams
   const rankMissingTeams = async () => {
     if (!datasetPath || !missingTeamNumbers.length) {
-      setError('No missing teams to rank');
+      setError("No missing teams to rank");
       return;
     }
-    
+
     setIsRankingMissingTeams(true);
     setError(null);
-    
+
     try {
       // Convert priorities to the format expected by the backend
       const simplePriorities = [];
@@ -713,82 +766,94 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
         simplePriorities.push({
           id: priority.id,
           weight: priority.weight,
-          reason: priority.reason || null
+          reason: priority.reason || null,
         });
       }
-      
+
       // Make the API call to rank missing teams
-      const response = await fetch('http://localhost:8000/api/picklist/rank-missing-teams', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          unified_dataset_path: datasetPath,
-          missing_team_numbers: missingTeamNumbers,
-          ranked_teams: picklist,
-          your_team_number: yourTeamNumber,
-          pick_position: pickPosition,
-          priorities: simplePriorities
-        })
-      });
-      
+      const response = await fetch(
+        "http://localhost:8000/api/picklist/rank-missing-teams",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            unified_dataset_path: datasetPath,
+            missing_team_numbers: missingTeamNumbers,
+            ranked_teams: picklist,
+            your_team_number: yourTeamNumber,
+            pick_position: pickPosition,
+            priorities: simplePriorities,
+          }),
+        },
+      );
+
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.detail || 'Failed to rank missing teams');
+        throw new Error(errorData.detail || "Failed to rank missing teams");
       }
-      
+
       const data: MissingTeamsResult = await response.json();
-      
-      if (data.status === 'success' && data.missing_team_rankings) {
+
+      if (data.status === "success" && data.missing_team_rankings) {
         // Filter out any fallback teams that were re-ranked
-        const rerankedTeamNumbers = data.missing_team_rankings.map(team => team.team_number);
-        const filteredPicklist = picklist.filter(team => 
-          !team.is_fallback || !rerankedTeamNumbers.includes(team.team_number)
+        const rerankedTeamNumbers = data.missing_team_rankings.map(
+          (team) => team.team_number,
         );
-        
+        const filteredPicklist = picklist.filter(
+          (team) =>
+            !team.is_fallback ||
+            !rerankedTeamNumbers.includes(team.team_number),
+        );
+
         // Merge properly ranked missing teams with filtered picklist
-        const updatedPicklist = [...filteredPicklist, ...data.missing_team_rankings];
-        
+        const updatedPicklist = [
+          ...filteredPicklist,
+          ...data.missing_team_rankings,
+        ];
+
         // Sort by score (highest to lowest)
         updatedPicklist.sort((a, b) => b.score - a.score);
-        
+
         // Update state
         setPicklist(updatedPicklist);
         setTotalPages(Math.ceil(updatedPicklist.length / teamsPerPage));
-        
+
         // Show success message
-        setSuccessMessage(`Successfully replaced ${data.missing_team_rankings.length} auto-added teams with proper rankings!`);
+        setSuccessMessage(
+          `Successfully replaced ${data.missing_team_rankings.length} auto-added teams with proper rankings!`,
+        );
         setTimeout(() => setSuccessMessage(null), 3000);
-        
+
         // Call the callback if provided
         if (onPicklistGenerated) {
           onPicklistGenerated({
-            status: 'success',
+            status: "success",
             picklist: updatedPicklist,
-            analysis: analysis as PicklistAnalysis
+            analysis: analysis as PicklistAnalysis,
           });
         }
       } else {
-        setError(data.message || 'Error ranking missing teams');
+        setError(data.message || "Error ranking missing teams");
       }
     } catch (err: any) {
-      setError(err.message || 'Error connecting to server');
-      console.error('Error ranking missing teams:', err);
+      setError(err.message || "Error connecting to server");
+      console.error("Error ranking missing teams:", err);
     } finally {
       setIsRankingMissingTeams(false);
       setShowMissingTeamsModal(false);
     }
   };
-  
+
   // Handle skipping the missing teams ranking
   const handleSkipMissingTeams = () => {
     setShowMissingTeamsModal(false);
     setMissingTeamNumbers([]);
-    
+
     // When skipping, ensure the picklist is properly sorted by score
     const sortedPicklist = [...picklist].sort((a, b) => b.score - a.score);
     setPicklist(sortedPicklist);
   };
-  
+
   // Handle team position change
   const handlePositionChange = (teamIndex: number, newPosition: number) => {
     // Validate the new position
@@ -797,47 +862,80 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
       setTimeout(() => setError(null), 3000);
       return;
     }
-    
+
     // Convert from 1-based UI position to 0-based array index
     const newIndex = newPosition - 1;
-    
+
     // Create a copy of the current picklist
     const newPicklist = [...picklist];
-    
+
     // Remove the team from its current position
     const [teamToMove] = newPicklist.splice(teamIndex, 1);
-    
+
     // Insert the team at the new position
     newPicklist.splice(newIndex, 0, teamToMove);
-    
+
     // Update the picklist
     setPicklist(newPicklist);
-    
+
     // Recalculate total pages
     setTotalPages(Math.ceil(newPicklist.length / teamsPerPage));
-    
+
     // Show feedback that rankings changed
-    setSuccessMessage('Team position updated');
+    setSuccessMessage("Team position updated");
     setTimeout(() => setSuccessMessage(null), 2000);
   };
-  
+
+  const toggleTeamSelection = (teamNumber: number) => {
+    setSelectedTeams((prev) => {
+      const exists = prev.includes(teamNumber);
+      if (exists) {
+        return prev.filter((n) => n !== teamNumber);
+      }
+      if (prev.length >= 3) return prev;
+      return [...prev, teamNumber];
+    });
+  };
+
+  const applyComparison = (teams: Team[]) => {
+    // Find indices of currently selected teams
+    const indices = selectedTeams
+      .map((num) => picklist.findIndex((t) => t.team_number === num))
+      .filter((i) => i !== -1)
+      .sort((a, b) => a - b);
+    const newList = [...picklist];
+    teams.forEach((team, idx) => {
+      const targetIndex = indices[idx];
+      if (targetIndex !== undefined) {
+        newList[targetIndex] = team;
+      }
+    });
+    setPicklist(newList);
+    setSelectedTeams([]);
+  };
+
   // Decide which loading/progress indicator to show
   if ((isLoading && !picklist.length) || batchProcessingActive) {
     // If batch processing is active, show the batch progress indicator
     if (batchProcessingActive && batchProcessingInfo) {
       return (
-        <BatchProgressIndicator 
-          batchInfo={batchProcessingInfo} 
-          elapsedTime={elapsedTime} 
+        <BatchProgressIndicator
+          batchInfo={batchProcessingInfo}
+          elapsedTime={elapsedTime}
         />
       );
     }
-    
+
     // Show estimated time progress indicator for non-batch processing
     if (estimatedTime > 0) {
-      return <ProgressIndicator estimatedTime={estimatedTime} teamCount={datasetPath ? 75 : 0} />;
+      return (
+        <ProgressIndicator
+          estimatedTime={estimatedTime}
+          teamCount={datasetPath ? 75 : 0}
+        />
+      );
     }
-    
+
     // Fall back to simple spinner if no time estimate
     return (
       <div className="flex justify-center items-center h-64">
@@ -846,385 +944,496 @@ const PicklistGenerator: React.FC<PicklistGeneratorProps> = ({
       </div>
     );
   }
-  
+
   // Don't show the picklist if batch processing is active
   if (batchProcessingActive) {
     return null;
   }
-  
+
   return (
-    <div className="bg-white rounded-lg shadow-md p-6">
-      {/* Missing Teams Modal */}
-      {showMissingTeamsModal && (
-        <MissingTeamsModal
-          missingTeamCount={missingTeamNumbers.length}
-          onRankMissingTeams={rankMissingTeams}
-          onSkip={handleSkipMissingTeams}
-          isLoading={isRankingMissingTeams}
-        />
-      )}
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-xl font-bold">
-          {pickPosition.charAt(0).toUpperCase() + pickPosition.slice(1)} Pick Rankings
-        </h2>
-        <div className="flex items-center space-x-4">
-          {/* Batching Toggle */}
-          {!isLocked && (
-            <label className="flex items-center space-x-2 text-sm">
-              <input
-                type="checkbox"
-                checked={useBatching}
-                onChange={(e) => {
-                  const newValue = e.target.checked;
-                  console.log('Toggling useBatching from', useBatching, 'to', newValue);
-                  setUseBatching(newValue);
-                  console.log('useBatching will be saved to localStorage as:', newValue);
-                }}
-                className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
-              />
-              <span>Use batch processing (recommended for large datasets)</span>
-            </label>
-          )}
-          <div className="flex space-x-2">
-            {isEditing ? (
-            <>
-              <button
-                onClick={updatePicklist}
-                disabled={isLoading}
-                className="px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700 disabled:bg-green-300"
-              >
-                Save Changes
-              </button>
-              <button
-                onClick={() => setIsEditing(false)}
-                className="px-3 py-1 bg-gray-400 text-white rounded hover:bg-gray-500"
-              >
-                Cancel
-              </button>
-            </>
-          ) : (
-            <>
-              {!isLocked && (
-                <button
-                  onClick={() => setIsEditing(true)}
-                  className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
-                >
-                  Edit Rankings
-                </button>
-              )}
-              <button
-                onClick={() => setShowAnalysis(!showAnalysis)}
-                className="px-3 py-1 bg-purple-600 text-white rounded hover:bg-purple-700"
-              >
-                {showAnalysis ? 'Hide Analysis' : 'Show Analysis'}
-              </button>
-              {!isLocked && (
-                <button
-                  onClick={generatePicklist}
-                  disabled={isLoading}
-                  className="px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700 disabled:bg-green-300"
-                >
-                  {isLoading ? 'Regenerating...' : 'Regenerate Picklist'}
-                </button>
-              )}
-              {!isLocked && picklist.length > 0 && (
-                <button
-                  onClick={clearPicklist}
-                  className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700"
-                >
-                  Clear Picklist
-                </button>
-              )}
-            </>
-          )}
-          </div>
-        </div>
-      </div>
-      
-      {error && (
-        <div className="p-3 mb-4 bg-red-100 text-red-700 rounded">
-          {error}
-        </div>
-      )}
-      
-      {successMessage && (
-        <div className="p-3 mb-4 bg-green-100 text-green-700 rounded">
-          {successMessage}
-        </div>
-      )}
-      
-      {showAnalysis && analysis && (
-        <div className="mb-6 bg-purple-50 p-4 rounded-lg border border-purple-200">
-          <h3 className="font-bold text-purple-800 mb-2">GPT Analysis</h3>
-          
-          <div className="space-y-3">
-            <div>
-              <h4 className="font-semibold text-purple-700">Draft Reasoning:</h4>
-              <p className="text-sm text-gray-700">{analysis.draft_reasoning}</p>
-            </div>
-            
-            <div>
-              <h4 className="font-semibold text-purple-700">Critical Evaluation:</h4>
-              <p className="text-sm text-gray-700">{analysis.evaluation}</p>
-            </div>
-            
-            <div>
-              <h4 className="font-semibold text-purple-700">Final Recommendations:</h4>
-              <p className="text-sm text-gray-700">{analysis.final_recommendations}</p>
-            </div>
-          </div>
-        </div>
-      )}
-      
-      {/* Pagination Controls */}
-      <div className="flex flex-col sm:flex-row justify-between items-center mb-4 py-2 border-b border-t">
-        <div className="mb-2 sm:mb-0">
-          <span className="mr-2">Teams per page:</span>
-          <select
-            value={teamsPerPage}
-            onChange={(e) => {
-              const newTeamsPerPage = parseInt(e.target.value);
-              setTeamsPerPage(newTeamsPerPage);
-              // Adjust current page to keep showing the first team currently visible
-              const firstTeamOnCurrentPage = (currentPage - 1) * teamsPerPage + 1;
-              const newPage = Math.ceil(firstTeamOnCurrentPage / newTeamsPerPage);
-              setCurrentPage(Math.max(1, Math.min(newPage, Math.ceil(picklist.length / newTeamsPerPage))));
-            }}
-            className="border rounded p-1"
-          >
-            <option value="5">5</option>
-            <option value="10">10</option>
-            <option value="15">15</option>
-            <option value="25">25</option>
-            <option value="50">50</option>
-          </select>
-        </div>
-        
-        <div className="flex items-center">
-          <button
-            onClick={() => setCurrentPage(1)}
-            disabled={currentPage === 1}
-            className={`px-2 py-1 rounded ${currentPage === 1 ? 'text-gray-400' : 'text-blue-600 hover:bg-blue-50'}`}
-            title="First page"
-          >
-            &laquo;
-          </button>
-          <button
-            onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
-            disabled={currentPage === 1}
-            className={`px-3 py-1 rounded ${currentPage === 1 ? 'text-gray-400' : 'text-blue-600 hover:bg-blue-50'}`}
-            title="Previous page"
-          >
-            &lsaquo;
-          </button>
-          
-          <span className="mx-2">
-            Page {currentPage} of {totalPages || 1}
-          </span>
-          
-          <button
-            onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
-            disabled={currentPage >= totalPages}
-            className={`px-3 py-1 rounded ${currentPage >= totalPages ? 'text-gray-400' : 'text-blue-600 hover:bg-blue-50'}`}
-            title="Next page"
-          >
-            &rsaquo;
-          </button>
-          <button
-            onClick={() => setCurrentPage(totalPages)}
-            disabled={currentPage >= totalPages}
-            className={`px-2 py-1 rounded ${currentPage >= totalPages ? 'text-gray-400' : 'text-blue-600 hover:bg-blue-50'}`}
-            title="Last page"
-          >
-            &raquo;
-          </button>
-        </div>
-        
-        <div className="mt-2 sm:mt-0 text-sm text-gray-500">
-          {picklist.length > 0 ? (
-            <span>
-              Showing {Math.min((currentPage - 1) * teamsPerPage + 1, picklist.length)}-
-              {Math.min(currentPage * teamsPerPage, picklist.length)} of {picklist.length} teams
-            </span>
-          ) : (
-            <span>No teams to display</span>
-          )}
-        </div>
-      </div>
-      
-      <div className="overflow-hidden">
-        {isEditing ? (
-          <div className="space-y-3">
-            <p className="text-sm text-blue-600 italic mb-2">
-              Edit team positions by changing their rank numbers, then click "Save Changes" when done.
-            </p>
-            
-            {/* Get current page of teams */}
-            {picklist
-              .slice((currentPage - 1) * teamsPerPage, currentPage * teamsPerPage)
-              .map((team, pageIndex) => {
-                // Get absolute index in full list
-                const index = (currentPage - 1) * teamsPerPage + pageIndex;
-                
-                return (
-                  <div 
-                    key={team.team_number} 
-                    className="p-3 bg-white rounded border border-gray-300 shadow-sm flex items-center hover:bg-blue-50 transition-colors duration-150"
+    <>
+      <div className="bg-white rounded-lg shadow-md p-6">
+        {/* Missing Teams Modal */}
+        {showMissingTeamsModal && (
+          <MissingTeamsModal
+            missingTeamCount={missingTeamNumbers.length}
+            onRankMissingTeams={rankMissingTeams}
+            onSkip={handleSkipMissingTeams}
+            isLoading={isRankingMissingTeams}
+          />
+        )}
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-bold">
+            {pickPosition.charAt(0).toUpperCase() + pickPosition.slice(1)} Pick
+            Rankings
+          </h2>
+          <div className="flex items-center space-x-4">
+            {/* Batching Toggle */}
+            {!isLocked && (
+              <label className="flex items-center space-x-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={useBatching}
+                  onChange={(e) => {
+                    const newValue = e.target.checked;
+                    console.log(
+                      "Toggling useBatching from",
+                      useBatching,
+                      "to",
+                      newValue,
+                    );
+                    setUseBatching(newValue);
+                    console.log(
+                      "useBatching will be saved to localStorage as:",
+                      newValue,
+                    );
+                  }}
+                  className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+                />
+                <span>
+                  Use batch processing (recommended for large datasets)
+                </span>
+              </label>
+            )}
+            <div className="flex space-x-2">
+              {isEditing ? (
+                <>
+                  <button
+                    onClick={updatePicklist}
+                    disabled={isLoading}
+                    className="px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700 disabled:bg-green-300"
                   >
-                    <div className="mr-3 flex items-center">
-                      <input
-                        type="number"
-                        min="1"
-                        max={picklist.length}
-                        value={index + 1}
-                        onChange={(e) => handlePositionChange(index, parseInt(e.target.value) || 1)}
-                        className="w-12 p-1 border border-gray-300 rounded text-center font-bold text-blue-600"
-                      />
-                    </div>
-                    <div className="flex-1">
-                      <div className="font-medium">
-                        Team {team.team_number}: {team.nickname}
-                        {team.is_fallback && (
-                          <span className="ml-2 px-2 py-0.5 text-xs bg-yellow-100 text-yellow-800 rounded-full" title="This team was automatically added to complete the picklist">
-                            Auto-added
-                          </span>
-                        )}
-                      </div>
-                      <div className="text-sm text-gray-600">Score: {team.score.toFixed(2)}</div>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      {onExcludeTeam && !isLocked && (
-                        <button
-                          onClick={() => onExcludeTeam(team.team_number)}
-                          className="px-2 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700"
-                          title="Exclude team from all picklists"
-                        >
-                          Exclude
-                        </button>
-                      )}
-                      <div className="text-gray-400">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                          <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
+                    Save Changes
+                  </button>
+                  <button
+                    onClick={() => setIsEditing(false)}
+                    className="px-3 py-1 bg-gray-400 text-white rounded hover:bg-gray-500"
+                  >
+                    Cancel
+                  </button>
+                </>
+              ) : (
+                <>
+                  {!isLocked && (
+                    <button
+                      onClick={() => setIsEditing(true)}
+                      className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                    >
+                      Edit Rankings
+                    </button>
+                  )}
+                  <button
+                    onClick={() => setShowAnalysis(!showAnalysis)}
+                    className="px-3 py-1 bg-purple-600 text-white rounded hover:bg-purple-700"
+                  >
+                    {showAnalysis ? "Hide Analysis" : "Show Analysis"}
+                  </button>
+                  {!isLocked && (
+                    <button
+                      onClick={generatePicklist}
+                      disabled={isLoading}
+                      className="px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700 disabled:bg-green-300"
+                    >
+                      {isLoading ? "Regenerating..." : "Regenerate Picklist"}
+                    </button>
+                  )}
+                  {!isLocked && picklist.length > 0 && (
+                    <button
+                      onClick={clearPicklist}
+                      className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700"
+                    >
+                      Clear Picklist
+                    </button>
+                  )}
+                </>
+              )}
+            </div>
           </div>
-        ) : (
-          <div className="space-y-2">
-            {/* Get current page of teams */}
-            {picklist
-              .slice((currentPage - 1) * teamsPerPage, currentPage * teamsPerPage)
-              .map((team, pageIndex) => {
-                // Get absolute index in full list
-                const index = (currentPage - 1) * teamsPerPage + pageIndex;
-                
-                return (
-                  <div key={team.team_number} className="p-3 bg-white rounded border flex hover:bg-gray-50">
-                    <div className="mr-3 text-lg font-bold text-gray-500">{index + 1}</div>
-                    <div className="flex-1">
-                      <div className="font-medium">
-                        Team {team.team_number}: {team.nickname}
+        </div>
+
+        {error && (
+          <div className="p-3 mb-4 bg-red-100 text-red-700 rounded">
+            {error}
+          </div>
+        )}
+
+        {successMessage && (
+          <div className="p-3 mb-4 bg-green-100 text-green-700 rounded">
+            {successMessage}
+          </div>
+        )}
+
+        {showAnalysis && analysis && (
+          <div className="mb-6 bg-purple-50 p-4 rounded-lg border border-purple-200">
+            <h3 className="font-bold text-purple-800 mb-2">GPT Analysis</h3>
+
+            <div className="space-y-3">
+              <div>
+                <h4 className="font-semibold text-purple-700">
+                  Draft Reasoning:
+                </h4>
+                <p className="text-sm text-gray-700">
+                  {analysis.draft_reasoning}
+                </p>
+              </div>
+
+              <div>
+                <h4 className="font-semibold text-purple-700">
+                  Critical Evaluation:
+                </h4>
+                <p className="text-sm text-gray-700">{analysis.evaluation}</p>
+              </div>
+
+              <div>
+                <h4 className="font-semibold text-purple-700">
+                  Final Recommendations:
+                </h4>
+                <p className="text-sm text-gray-700">
+                  {analysis.final_recommendations}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Pagination Controls */}
+        <div className="flex flex-col sm:flex-row justify-between items-center mb-4 py-2 border-b border-t">
+          <div className="mb-2 sm:mb-0">
+            <span className="mr-2">Teams per page:</span>
+            <select
+              value={teamsPerPage}
+              onChange={(e) => {
+                const newTeamsPerPage = parseInt(e.target.value);
+                setTeamsPerPage(newTeamsPerPage);
+                // Adjust current page to keep showing the first team currently visible
+                const firstTeamOnCurrentPage =
+                  (currentPage - 1) * teamsPerPage + 1;
+                const newPage = Math.ceil(
+                  firstTeamOnCurrentPage / newTeamsPerPage,
+                );
+                setCurrentPage(
+                  Math.max(
+                    1,
+                    Math.min(
+                      newPage,
+                      Math.ceil(picklist.length / newTeamsPerPage),
+                    ),
+                  ),
+                );
+              }}
+              className="border rounded p-1"
+            >
+              <option value="5">5</option>
+              <option value="10">10</option>
+              <option value="15">15</option>
+              <option value="25">25</option>
+              <option value="50">50</option>
+            </select>
+          </div>
+
+          <div className="flex items-center">
+            <button
+              onClick={() => setCurrentPage(1)}
+              disabled={currentPage === 1}
+              className={`px-2 py-1 rounded ${currentPage === 1 ? "text-gray-400" : "text-blue-600 hover:bg-blue-50"}`}
+              title="First page"
+            >
+              &laquo;
+            </button>
+            <button
+              onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+              disabled={currentPage === 1}
+              className={`px-3 py-1 rounded ${currentPage === 1 ? "text-gray-400" : "text-blue-600 hover:bg-blue-50"}`}
+              title="Previous page"
+            >
+              &lsaquo;
+            </button>
+
+            <span className="mx-2">
+              Page {currentPage} of {totalPages || 1}
+            </span>
+
+            <button
+              onClick={() =>
+                setCurrentPage((prev) => Math.min(totalPages, prev + 1))
+              }
+              disabled={currentPage >= totalPages}
+              className={`px-3 py-1 rounded ${currentPage >= totalPages ? "text-gray-400" : "text-blue-600 hover:bg-blue-50"}`}
+              title="Next page"
+            >
+              &rsaquo;
+            </button>
+            <button
+              onClick={() => setCurrentPage(totalPages)}
+              disabled={currentPage >= totalPages}
+              className={`px-2 py-1 rounded ${currentPage >= totalPages ? "text-gray-400" : "text-blue-600 hover:bg-blue-50"}`}
+              title="Last page"
+            >
+              &raquo;
+            </button>
+          </div>
+
+          <div className="mt-2 sm:mt-0 text-sm text-gray-500">
+            {picklist.length > 0 ? (
+              <span>
+                Showing{" "}
+                {Math.min(
+                  (currentPage - 1) * teamsPerPage + 1,
+                  picklist.length,
+                )}
+                -{Math.min(currentPage * teamsPerPage, picklist.length)} of{" "}
+                {picklist.length} teams
+              </span>
+            ) : (
+              <span>No teams to display</span>
+            )}
+          </div>
+        </div>
+
+        {selectedTeams.length > 1 && (
+          <div className="my-2">
+            <button
+              onClick={() => setShowComparison(true)}
+              className="px-3 py-1 bg-blue-600 text-white rounded"
+            >
+              Compare & Re-Rank
+            </button>
+          </div>
+        )}
+
+        <div className="overflow-hidden">
+          {isEditing ? (
+            <div className="space-y-3">
+              <p className="text-sm text-blue-600 italic mb-2">
+                Edit team positions by changing their rank numbers, then click
+                "Save Changes" when done.
+              </p>
+
+              {/* Get current page of teams */}
+              {picklist
+                .slice(
+                  (currentPage - 1) * teamsPerPage,
+                  currentPage * teamsPerPage,
+                )
+                .map((team, pageIndex) => {
+                  // Get absolute index in full list
+                  const index = (currentPage - 1) * teamsPerPage + pageIndex;
+
+                  return (
+                    <div
+                      key={team.team_number}
+                      className="p-3 bg-white rounded border border-gray-300 shadow-sm flex items-center hover:bg-blue-50 transition-colors duration-150"
+                    >
+                      <div className="mr-3 flex items-center">
+                        <input
+                          type="number"
+                          min="1"
+                          max={picklist.length}
+                          value={index + 1}
+                          onChange={(e) =>
+                            handlePositionChange(
+                              index,
+                              parseInt(e.target.value) || 1,
+                            )
+                          }
+                          className="w-12 p-1 border border-gray-300 rounded text-center font-bold text-blue-600"
+                        />
+                      </div>
+                      <div className="flex-1">
+                        <div className="font-medium">
+                          Team {team.team_number}: {team.nickname}
+                          {team.is_fallback && (
+                            <span
+                              className="ml-2 px-2 py-0.5 text-xs bg-yellow-100 text-yellow-800 rounded-full"
+                              title="This team was automatically added to complete the picklist"
+                            >
+                              Auto-added
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-sm text-gray-600">
+                          Score: {team.score.toFixed(2)}
+                        </div>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        {onExcludeTeam && !isLocked && (
+                          <button
+                            onClick={() => onExcludeTeam(team.team_number)}
+                            className="px-2 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700"
+                            title="Exclude team from all picklists"
+                          >
+                            Exclude
+                          </button>
+                        )}
+                        <div className="text-gray-400">
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            className="h-5 w-5"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                          >
+                            <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {/* Get current page of teams */}
+              {picklist
+                .slice(
+                  (currentPage - 1) * teamsPerPage,
+                  currentPage * teamsPerPage,
+                )
+                .map((team, pageIndex) => {
+                  // Get absolute index in full list
+                  const index = (currentPage - 1) * teamsPerPage + pageIndex;
+
+                  return (
+                    <div
+                      key={team.team_number}
+                      className="p-3 bg-white rounded border flex hover:bg-gray-50"
+                    >
+                      <input
+                        type="checkbox"
+                        className="mr-3"
+                        checked={selectedTeams.includes(team.team_number)}
+                        onChange={() => toggleTeamSelection(team.team_number)}
+                        disabled={isLocked}
+                      />
+                      <div className="mr-3 text-lg font-bold text-gray-500">
+                        {index + 1}
+                      </div>
+                      <div className="flex-1">
+                        <div className="font-medium">
+                          Team {team.team_number}: {team.nickname}
+                          {team.is_fallback && (
+                            <span
+                              className="ml-2 px-2 py-0.5 text-xs bg-yellow-100 text-yellow-800 rounded-full"
+                              title="This team was automatically added to complete the picklist"
+                            >
+                              Auto-added
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-sm text-gray-600">
+                          Score: {team.score.toFixed(2)}
+                        </div>
+                        <div
+                          className={`text-sm mt-1 ${team.is_fallback ? "italic text-yellow-700" : ""}`}
+                        >
+                          {team.reasoning}
+                        </div>
                         {team.is_fallback && (
-                          <span className="ml-2 px-2 py-0.5 text-xs bg-yellow-100 text-yellow-800 rounded-full" title="This team was automatically added to complete the picklist">
-                            Auto-added
-                          </span>
+                          <div className="text-xs mt-1 text-red-500">
+                            Note: This team was added automatically because it
+                            was missing from the GPT response.
+                          </div>
                         )}
                       </div>
-                      <div className="text-sm text-gray-600">Score: {team.score.toFixed(2)}</div>
-                      <div className={`text-sm mt-1 ${team.is_fallback ? 'italic text-yellow-700' : ''}`}>
-                        {team.reasoning}
-                      </div>
-                      {team.is_fallback && (
-                        <div className="text-xs mt-1 text-red-500">
-                          Note: This team was added automatically because it was missing from the GPT response.
+                      {onExcludeTeam && !isLocked && (
+                        <div className="ml-2 flex items-center">
+                          <button
+                            onClick={() => onExcludeTeam(team.team_number)}
+                            className="px-2 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700"
+                            title="Exclude team from all picklists"
+                          >
+                            Exclude
+                          </button>
                         </div>
                       )}
                     </div>
-                    {onExcludeTeam && !isLocked && (
-                      <div className="ml-2 flex items-center">
-                        <button
-                          onClick={() => onExcludeTeam(team.team_number)}
-                          className="px-2 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700"
-                          title="Exclude team from all picklists"
-                        >
-                          Exclude
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
+                  );
+                })}
+            </div>
+          )}
+        </div>
+
+        {/* Bottom Pagination for convenience with longer lists */}
+        {totalPages > 1 && (
+          <div className="mt-4 flex justify-center">
+            <button
+              onClick={() => setCurrentPage(1)}
+              disabled={currentPage === 1}
+              className={`px-2 py-1 rounded ${currentPage === 1 ? "text-gray-400" : "text-blue-600 hover:bg-blue-50"}`}
+              title="First page"
+            >
+              &laquo;
+            </button>
+            <button
+              onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+              disabled={currentPage === 1}
+              className={`px-3 py-1 rounded ${currentPage === 1 ? "text-gray-400" : "text-blue-600 hover:bg-blue-50"}`}
+              title="Previous page"
+            >
+              &lsaquo;
+            </button>
+
+            {/* Page number buttons */}
+            {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+              // Show pages around current page
+              let pageNum;
+              if (totalPages <= 5) {
+                pageNum = i + 1;
+              } else if (currentPage <= 3) {
+                pageNum = i + 1;
+              } else if (currentPage >= totalPages - 2) {
+                pageNum = totalPages - 4 + i;
+              } else {
+                pageNum = currentPage - 2 + i;
+              }
+
+              return (
+                <button
+                  key={pageNum}
+                  onClick={() => setCurrentPage(pageNum)}
+                  className={`px-3 py-1 mx-1 rounded ${currentPage === pageNum ? "bg-blue-600 text-white" : "text-blue-600 hover:bg-blue-50"}`}
+                >
+                  {pageNum}
+                </button>
+              );
+            })}
+
+            <button
+              onClick={() =>
+                setCurrentPage((prev) => Math.min(totalPages, prev + 1))
+              }
+              disabled={currentPage >= totalPages}
+              className={`px-3 py-1 rounded ${currentPage >= totalPages ? "text-gray-400" : "text-blue-600 hover:bg-blue-50"}`}
+              title="Next page"
+            >
+              &rsaquo;
+            </button>
+            <button
+              onClick={() => setCurrentPage(totalPages)}
+              disabled={currentPage >= totalPages}
+              className={`px-2 py-1 rounded ${currentPage >= totalPages ? "text-gray-400" : "text-blue-600 hover:bg-blue-50"}`}
+              title="Last page"
+            >
+              &raquo;
+            </button>
           </div>
         )}
       </div>
-      
-      {/* Bottom Pagination for convenience with longer lists */}
-      {totalPages > 1 && (
-        <div className="mt-4 flex justify-center">
-          <button
-            onClick={() => setCurrentPage(1)}
-            disabled={currentPage === 1}
-            className={`px-2 py-1 rounded ${currentPage === 1 ? 'text-gray-400' : 'text-blue-600 hover:bg-blue-50'}`}
-            title="First page"
-          >
-            &laquo;
-          </button>
-          <button
-            onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
-            disabled={currentPage === 1}
-            className={`px-3 py-1 rounded ${currentPage === 1 ? 'text-gray-400' : 'text-blue-600 hover:bg-blue-50'}`}
-            title="Previous page"
-          >
-            &lsaquo;
-          </button>
-          
-          {/* Page number buttons */}
-          {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
-            // Show pages around current page
-            let pageNum;
-            if (totalPages <= 5) {
-              pageNum = i + 1;
-            } else if (currentPage <= 3) {
-              pageNum = i + 1;
-            } else if (currentPage >= totalPages - 2) {
-              pageNum = totalPages - 4 + i;
-            } else {
-              pageNum = currentPage - 2 + i;
-            }
-            
-            return (
-              <button
-                key={pageNum}
-                onClick={() => setCurrentPage(pageNum)}
-                className={`px-3 py-1 mx-1 rounded ${currentPage === pageNum ? 'bg-blue-600 text-white' : 'text-blue-600 hover:bg-blue-50'}`}
-              >
-                {pageNum}
-              </button>
-            );
-          })}
-          
-          <button
-            onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
-            disabled={currentPage >= totalPages}
-            className={`px-3 py-1 rounded ${currentPage >= totalPages ? 'text-gray-400' : 'text-blue-600 hover:bg-blue-50'}`}
-            title="Next page"
-          >
-            &rsaquo;
-          </button>
-          <button
-            onClick={() => setCurrentPage(totalPages)}
-            disabled={currentPage >= totalPages}
-            className={`px-2 py-1 rounded ${currentPage >= totalPages ? 'text-gray-400' : 'text-blue-600 hover:bg-blue-50'}`}
-            title="Last page"
-          >
-            &raquo;
-          </button>
-        </div>
-      )}
-    </div>
+      <TeamComparisonModal
+        isOpen={showComparison}
+        onClose={() => setShowComparison(false)}
+        teamNumbers={selectedTeams}
+        datasetPath={datasetPath}
+        yourTeamNumber={yourTeamNumber}
+        prioritiesMap={
+          allPriorities || {
+            first: priorities,
+            second: priorities,
+            third: priorities,
+          }
+        }
+        onApply={applyComparison}
+      />
+    </>
   );
 };
 

--- a/frontend/src/components/TeamComparisonModal.tsx
+++ b/frontend/src/components/TeamComparisonModal.tsx
@@ -1,0 +1,159 @@
+import React, { useState } from "react";
+
+interface Team {
+  team_number: number;
+  nickname: string;
+  score: number;
+  reasoning: string;
+}
+
+interface MetricPriority {
+  id: string;
+  weight: number;
+  reason?: string | null;
+}
+
+interface PrioritiesMap {
+  first: MetricPriority[];
+  second: MetricPriority[];
+  third: MetricPriority[];
+}
+
+interface TeamComparisonModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  teamNumbers: number[];
+  datasetPath: string;
+  yourTeamNumber: number;
+  prioritiesMap: PrioritiesMap;
+  onApply: (teams: Team[]) => void;
+}
+
+const TeamComparisonModal: React.FC<TeamComparisonModalProps> = ({
+  isOpen,
+  onClose,
+  teamNumbers,
+  datasetPath,
+  yourTeamNumber,
+  prioritiesMap,
+  onApply,
+}) => {
+  const [pickPosition, setPickPosition] = useState<
+    "first" | "second" | "third"
+  >("first");
+  const [question, setQuestion] = useState("");
+  const [result, setResult] = useState<Team[] | null>(null);
+  const [summary, setSummary] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const compareTeams = async () => {
+    setIsLoading(true);
+    setResult(null);
+    setSummary(null);
+    try {
+      const simplePriorities = prioritiesMap[pickPosition].map((p) => ({
+        id: p.id,
+        weight: p.weight,
+        reason: p.reason || null,
+      }));
+      const response = await fetch(
+        "http://localhost:8000/api/picklist/compare-teams",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            unified_dataset_path: datasetPath,
+            team_numbers: teamNumbers,
+            your_team_number: yourTeamNumber,
+            pick_position: pickPosition,
+            priorities: simplePriorities,
+            question,
+          }),
+        },
+      );
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.detail || "Failed to compare teams");
+      }
+      const data = await response.json();
+      setResult(data.ordered_teams || []);
+      setSummary(data.summary || null);
+    } catch (err) {
+      console.error("Error comparing teams:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const apply = () => {
+    if (result) {
+      onApply(result);
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded p-4 w-full max-w-lg space-y-4">
+        <h3 className="text-lg font-semibold">Compare Selected Teams</h3>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Pick Strategy</label>
+          <select
+            value={pickPosition}
+            onChange={(e) =>
+              setPickPosition(e.target.value as "first" | "second" | "third")
+            }
+            className="border p-1 rounded w-full"
+          >
+            <option value="first">1st Pick</option>
+            <option value="second">2nd Pick</option>
+            <option value="third">3rd Pick</option>
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Optional Question</label>
+          <textarea
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            className="border p-1 rounded w-full"
+            rows={3}
+          />
+        </div>
+        <div className="flex justify-end space-x-2">
+          <button onClick={onClose} className="px-3 py-1 bg-gray-300 rounded">
+            Cancel
+          </button>
+          <button
+            onClick={compareTeams}
+            disabled={isLoading}
+            className="px-3 py-1 bg-blue-600 text-white rounded"
+          >
+            {isLoading ? "Comparing..." : "Compare"}
+          </button>
+        </div>
+        {result && (
+          <div className="space-y-2 border-t pt-3 mt-3">
+            {summary && <p className="text-sm">{summary}</p>}
+            <ol className="list-decimal list-inside space-y-1">
+              {result.map((team) => (
+                <li key={team.team_number} className="text-sm">
+                  {team.team_number} – {team.nickname}
+                </li>
+              ))}
+            </ol>
+            <div className="flex justify-end">
+              <button
+                onClick={apply}
+                className="px-3 py-1 bg-green-600 text-white rounded"
+              >
+                Apply Order
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TeamComparisonModal;

--- a/frontend/src/pages/PicklistView.tsx
+++ b/frontend/src/pages/PicklistView.tsx
@@ -1,7 +1,7 @@
 // frontend/src/pages/PicklistView.tsx
 
-import React, { useState, useEffect } from 'react';
-import PicklistGenerator from '../components/PicklistGenerator';
+import React, { useState, useEffect } from "react";
+import PicklistGenerator from "../components/PicklistGenerator";
 
 interface Team {
   team_number: number;
@@ -23,27 +23,35 @@ interface Metric {
 }
 
 const PicklistView: React.FC = () => {
-  const [datasetPath, setDatasetPath] = useState<string>('');
+  const [datasetPath, setDatasetPath] = useState<string>("");
   const [yourTeamNumber, setYourTeamNumber] = useState<number>(0);
-  const [activeTab, setActiveTab] = useState<'first' | 'second' | 'third'>('first');
-  
+  const [activeTab, setActiveTab] = useState<"first" | "second" | "third">(
+    "first",
+  );
+
   // Priorities for each pick position
-  const [firstPickPriorities, setFirstPickPriorities] = useState<MetricPriority[]>([]);
-  const [secondPickPriorities, setSecondPickPriorities] = useState<MetricPriority[]>([]);
-  const [thirdPickPriorities, setThirdPickPriorities] = useState<MetricPriority[]>([]);
-  
+  const [firstPickPriorities, setFirstPickPriorities] = useState<
+    MetricPriority[]
+  >([]);
+  const [secondPickPriorities, setSecondPickPriorities] = useState<
+    MetricPriority[]
+  >([]);
+  const [thirdPickPriorities, setThirdPickPriorities] = useState<
+    MetricPriority[]
+  >([]);
+
   // Available metrics
   const [universalMetrics, setUniversalMetrics] = useState<Metric[]>([]);
   const [gameMetrics, setGameMetrics] = useState<Metric[]>([]);
-  
+
   // Generated picklists
   const [firstPicklist, setFirstPicklist] = useState<Team[]>([]);
   const [secondPicklist, setSecondPicklist] = useState<Team[]>([]);
   const [thirdPicklist, setThirdPicklist] = useState<Team[]>([]);
-  
+
   // Track teams already picked in previous lists
   const [excludedTeams, setExcludedTeams] = useState<number[]>([]);
-  
+
   // Loading, error states
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -51,270 +59,310 @@ const PicklistView: React.FC = () => {
   const [isLocking, setIsLocking] = useState<boolean>(false);
   const [picklists, setPicklists] = useState<any[]>([]);
   const [hasLockedPicklist, setHasLockedPicklist] = useState<boolean>(false);
-  const [activeAllianceSelection, setActiveAllianceSelection] = useState<number | null>(null);
-  
+  const [activeAllianceSelection, setActiveAllianceSelection] = useState<
+    number | null
+  >(null);
+
   useEffect(() => {
     // Check for dataset and load metrics
     checkDatasetStatus();
     // Check for existing locked picklists
     fetchLockedPicklists();
   }, []);
-  
+
   // Update excluded teams when picklists change
   useEffect(() => {
     const excluded: number[] = [];
-    
+
     // Add teams from first pick if we're on second or third tab
-    if (activeTab === 'second' || activeTab === 'third') {
-      firstPicklist.slice(0, 1).forEach(team => {
+    if (activeTab === "second" || activeTab === "third") {
+      firstPicklist.slice(0, 1).forEach((team) => {
         excluded.push(team.team_number);
       });
     }
-    
+
     // Add teams from second pick if we're on third tab
-    if (activeTab === 'third') {
-      secondPicklist.slice(0, 1).forEach(team => {
+    if (activeTab === "third") {
+      secondPicklist.slice(0, 1).forEach((team) => {
         excluded.push(team.team_number);
       });
     }
-    
+
     setExcludedTeams(excluded);
   }, [activeTab, firstPicklist, secondPicklist]);
-  
+
   const checkDatasetStatus = async () => {
     try {
       // Check for unified dataset
-      const response = await fetch('http://localhost:8000/api/unified/status?event_key=2025arc&year=2025');
+      const response = await fetch(
+        "http://localhost:8000/api/unified/status?event_key=2025arc&year=2025",
+      );
       const data = await response.json();
-      
-      if (data.status === 'exists' && data.path) {
+
+      if (data.status === "exists" && data.path) {
         setDatasetPath(data.path);
         await fetchMetrics(data.path);
       }
     } catch (err) {
-      console.error('Error checking dataset status:', err);
-      setError('Error checking for datasets');
+      console.error("Error checking dataset status:", err);
+      setError("Error checking for datasets");
     } finally {
       setIsLoading(false);
     }
   };
-  
+
   const fetchMetrics = async (path: string) => {
     try {
-      const response = await fetch('http://localhost:8000/api/picklist/analyze', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ unified_dataset_path: path })
-      });
-      
+      const response = await fetch(
+        "http://localhost:8000/api/picklist/analyze",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ unified_dataset_path: path }),
+        },
+      );
+
       if (!response.ok) {
-        throw new Error('Failed to fetch metrics');
+        throw new Error("Failed to fetch metrics");
       }
-      
+
       const data = await response.json();
-      
-      if (data.status === 'success') {
+
+      if (data.status === "success") {
         setUniversalMetrics(data.universal_metrics || []);
         setGameMetrics(data.game_metrics || []);
-        
+
         // Get your team number from dataset if available
         if (data.your_team_number) {
           setYourTeamNumber(data.your_team_number);
         }
       }
     } catch (err) {
-      console.error('Error fetching metrics:', err);
-      setError('Error loading metrics data');
+      console.error("Error fetching metrics:", err);
+      setError("Error loading metrics data");
     }
   };
-  
+
   const handleAddMetric = (metric: Metric) => {
     const newPriority: MetricPriority = {
       id: metric.id,
-      weight: 1.0
+      weight: 1.0,
     };
-    
+
     // Add to the appropriate list based on active tab
-    if (activeTab === 'first') {
-      if (!firstPickPriorities.some(p => p.id === metric.id)) {
+    if (activeTab === "first") {
+      if (!firstPickPriorities.some((p) => p.id === metric.id)) {
         setFirstPickPriorities([...firstPickPriorities, newPriority]);
       }
-    } else if (activeTab === 'second') {
-      if (!secondPickPriorities.some(p => p.id === metric.id)) {
+    } else if (activeTab === "second") {
+      if (!secondPickPriorities.some((p) => p.id === metric.id)) {
         setSecondPickPriorities([...secondPickPriorities, newPriority]);
       }
-    } else if (activeTab === 'third') {
-      if (!thirdPickPriorities.some(p => p.id === metric.id)) {
+    } else if (activeTab === "third") {
+      if (!thirdPickPriorities.some((p) => p.id === metric.id)) {
         setThirdPickPriorities([...thirdPickPriorities, newPriority]);
       }
     }
   };
-  
+
   const handleRemovePriority = (metricId: string) => {
     // Remove from the appropriate list based on active tab
-    if (activeTab === 'first') {
-      setFirstPickPriorities(firstPickPriorities.filter(p => p.id !== metricId));
-    } else if (activeTab === 'second') {
-      setSecondPickPriorities(secondPickPriorities.filter(p => p.id !== metricId));
-    } else if (activeTab === 'third') {
-      setThirdPickPriorities(thirdPickPriorities.filter(p => p.id !== metricId));
+    if (activeTab === "first") {
+      setFirstPickPriorities(
+        firstPickPriorities.filter((p) => p.id !== metricId),
+      );
+    } else if (activeTab === "second") {
+      setSecondPickPriorities(
+        secondPickPriorities.filter((p) => p.id !== metricId),
+      );
+    } else if (activeTab === "third") {
+      setThirdPickPriorities(
+        thirdPickPriorities.filter((p) => p.id !== metricId),
+      );
     }
   };
-  
+
   const handleWeightChange = (metricId: string, weight: number) => {
     // Update weight in the appropriate list based on active tab
-    if (activeTab === 'first') {
-      setFirstPickPriorities(firstPickPriorities.map(p => 
-        p.id === metricId ? { ...p, weight } : p
-      ));
-    } else if (activeTab === 'second') {
-      setSecondPickPriorities(secondPickPriorities.map(p => 
-        p.id === metricId ? { ...p, weight } : p
-      ));
-    } else if (activeTab === 'third') {
-      setThirdPickPriorities(thirdPickPriorities.map(p => 
-        p.id === metricId ? { ...p, weight } : p
-      ));
+    if (activeTab === "first") {
+      setFirstPickPriorities(
+        firstPickPriorities.map((p) =>
+          p.id === metricId ? { ...p, weight } : p,
+        ),
+      );
+    } else if (activeTab === "second") {
+      setSecondPickPriorities(
+        secondPickPriorities.map((p) =>
+          p.id === metricId ? { ...p, weight } : p,
+        ),
+      );
+    } else if (activeTab === "third") {
+      setThirdPickPriorities(
+        thirdPickPriorities.map((p) =>
+          p.id === metricId ? { ...p, weight } : p,
+        ),
+      );
     }
   };
-  
+
   const fetchLockedPicklists = async () => {
     try {
-      const response = await fetch('http://localhost:8000/api/alliance/picklists');
+      const response = await fetch(
+        "http://localhost:8000/api/alliance/picklists",
+      );
       const data = await response.json();
-      
-      if (data.status === 'success') {
+
+      if (data.status === "success") {
         setPicklists(data.picklists || []);
-        
+
         // Check if there's a locked picklist for the current event and team
-        const currentPicklist = data.picklists.find((p: any) => 
-          p.team_number === yourTeamNumber && p.event_key === '2025arc'
+        const currentPicklist = data.picklists.find(
+          (p: any) =>
+            p.team_number === yourTeamNumber && p.event_key === "2025arc",
         );
-        
+
         setHasLockedPicklist(!!currentPicklist);
-        
+
         // Check if there's an active alliance selection
         if (currentPicklist) {
           // Fetch alliance selections for this picklist
-          const selectionResponse = await fetch(`http://localhost:8000/api/alliance/selection/${currentPicklist.id}`);
+          const selectionResponse = await fetch(
+            `http://localhost:8000/api/alliance/selection/${currentPicklist.id}`,
+          );
           const selectionData = await selectionResponse.json();
-          
-          if (selectionData.status === 'success' && selectionData.selection) {
+
+          if (selectionData.status === "success" && selectionData.selection) {
             setActiveAllianceSelection(selectionData.selection.id);
           }
         }
       }
     } catch (err) {
-      console.error('Error fetching locked picklists:', err);
+      console.error("Error fetching locked picklists:", err);
     }
   };
-  
+
   const handleLockPicklist = async () => {
     // Validate we have first and second picks
     if (!firstPicklist.length || !secondPicklist.length) {
-      setError('You must generate both first and second pick rankings before locking your picklist.');
+      setError(
+        "You must generate both first and second pick rankings before locking your picklist.",
+      );
       return;
     }
-    
+
     // Validate team number
     if (!yourTeamNumber) {
-      setError('You must enter your team number before locking your picklist.');
+      setError("You must enter your team number before locking your picklist.");
       return;
     }
-    
+
     setIsLocking(true);
     setError(null);
-    
+
     try {
       const requestBody = {
         team_number: yourTeamNumber,
-        event_key: '2025arc', // Hardcoded for now, could be made dynamic
-        year: 2025,           // Hardcoded for now, could be made dynamic
+        event_key: "2025arc", // Hardcoded for now, could be made dynamic
+        year: 2025, // Hardcoded for now, could be made dynamic
         first_pick_data: {
           teams: firstPicklist,
-          analysis: null,      // Add analysis if available
+          analysis: null, // Add analysis if available
           metadata: {
-            priorities: firstPickPriorities
-          }
+            priorities: firstPickPriorities,
+          },
         },
         second_pick_data: {
           teams: secondPicklist,
-          analysis: null,      // Add analysis if available
+          analysis: null, // Add analysis if available
           metadata: {
-            priorities: secondPickPriorities
-          }
+            priorities: secondPickPriorities,
+          },
         },
-        third_pick_data: thirdPicklist.length ? {
-          teams: thirdPicklist,
-          analysis: null,      // Add analysis if available
-          metadata: {
-            priorities: thirdPickPriorities
-          }
-        } : null
+        third_pick_data: thirdPicklist.length
+          ? {
+              teams: thirdPicklist,
+              analysis: null, // Add analysis if available
+              metadata: {
+                priorities: thirdPickPriorities,
+              },
+            }
+          : null,
       };
-      
-      const response = await fetch('http://localhost:8000/api/alliance/lock-picklist', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody)
-      });
-      
+
+      const response = await fetch(
+        "http://localhost:8000/api/alliance/lock-picklist",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(requestBody),
+        },
+      );
+
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.detail || 'Failed to lock picklist');
+        throw new Error(errorData.detail || "Failed to lock picklist");
       }
-      
+
       const data = await response.json();
-      
+
       // Update state with success message
-      setSuccessMessage('Picklist successfully locked! You can now proceed to the Alliance Selection screen.');
+      setSuccessMessage(
+        "Picklist successfully locked! You can now proceed to the Alliance Selection screen.",
+      );
       setHasLockedPicklist(true);
-      
+
       // Refresh the picklists
       fetchLockedPicklists();
-      
+
       // Clear success message after 5 seconds
       setTimeout(() => setSuccessMessage(null), 5000);
-      
     } catch (err: any) {
-      setError(err.message || 'Error locking picklist');
-      console.error('Error locking picklist:', err);
+      setError(err.message || "Error locking picklist");
+      console.error("Error locking picklist:", err);
     } finally {
       setIsLocking(false);
     }
   };
-  
-  const handlePicklistGenerated = (position: 'first' | 'second' | 'third', result: any) => {
-    if (result.status === 'success') {
-      if (position === 'first') {
+
+  const handlePicklistGenerated = (
+    position: "first" | "second" | "third",
+    result: any,
+  ) => {
+    if (result.status === "success") {
+      if (position === "first") {
         setFirstPicklist(result.picklist);
-      } else if (position === 'second') {
+      } else if (position === "second") {
         setSecondPicklist(result.picklist);
-      } else if (position === 'third') {
+      } else if (position === "third") {
         setThirdPicklist(result.picklist);
       }
     }
   };
-  
+
   const getActivePriorities = () => {
-    if (activeTab === 'first') return firstPickPriorities;
-    if (activeTab === 'second') return secondPickPriorities;
+    if (activeTab === "first") return firstPickPriorities;
+    if (activeTab === "second") return secondPickPriorities;
     return thirdPickPriorities;
   };
-  
+
   if (isLoading) {
-    return <div className="flex justify-center items-center h-64">
-      <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
-    </div>;
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+      </div>
+    );
   }
-  
+
   if (!datasetPath) {
     return (
       <div className="max-w-5xl mx-auto p-6">
         <div className="bg-white rounded-lg shadow-md p-6 text-center">
           <h2 className="text-xl font-bold mb-4">No Dataset Available</h2>
-          <p className="mb-4">Please build a unified dataset first before using the picklist builder.</p>
-          <a 
+          <p className="mb-4">
+            Please build a unified dataset first before using the picklist
+            builder.
+          </p>
+          <a
             href="/workflow"
             className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 inline-block"
           >
@@ -324,22 +372,22 @@ const PicklistView: React.FC = () => {
       </div>
     );
   }
-  
+
   return (
     <div className="max-w-6xl mx-auto p-6">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold">Alliance Selection Picklist</h1>
-        
+
         <div className="flex space-x-4">
           {/* Show Lock button only if we have first and second picks */}
-          {(firstPicklist.length > 0 && secondPicklist.length > 0) && (
+          {firstPicklist.length > 0 && secondPicklist.length > 0 && (
             <button
               onClick={handleLockPicklist}
               disabled={isLocking || hasLockedPicklist}
               className={`px-4 py-2 rounded font-medium flex items-center ${
                 hasLockedPicklist
-                  ? 'bg-green-600 text-white cursor-default'
-                  : 'bg-blue-600 text-white hover:bg-blue-700'
+                  ? "bg-green-600 text-white cursor-default"
+                  : "bg-blue-600 text-white hover:bg-blue-700"
               }`}
             >
               {isLocking ? (
@@ -349,29 +397,49 @@ const PicklistView: React.FC = () => {
                 </>
               ) : hasLockedPicklist ? (
                 <>
-                  <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clipRule="evenodd" />
+                  <svg
+                    className="w-4 h-4 mr-2"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z"
+                      clipRule="evenodd"
+                    />
                   </svg>
                   Picklist Locked
                 </>
               ) : (
                 <>
-                  <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clipRule="evenodd" />
+                  <svg
+                    className="w-4 h-4 mr-2"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z"
+                      clipRule="evenodd"
+                    />
                   </svg>
                   Lock Picklist
                 </>
               )}
             </button>
           )}
-          
+
           {/* Show Alliance Selection button if picklist is locked */}
           {hasLockedPicklist && (
             <a
-              href={`/alliance-selection${activeAllianceSelection ? `/${activeAllianceSelection}` : ''}`}
+              href={`/alliance-selection${activeAllianceSelection ? `/${activeAllianceSelection}` : ""}`}
               className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 font-medium flex items-center"
             >
-              <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
+              <svg
+                className="w-4 h-4 mr-2"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
                 <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z" />
               </svg>
               Alliance Selection
@@ -379,19 +447,17 @@ const PicklistView: React.FC = () => {
           )}
         </div>
       </div>
-      
+
       {error && (
-        <div className="p-3 mb-4 bg-red-100 text-red-700 rounded">
-          {error}
-        </div>
+        <div className="p-3 mb-4 bg-red-100 text-red-700 rounded">{error}</div>
       )}
-      
+
       {successMessage && (
         <div className="p-3 mb-4 bg-green-100 text-green-700 rounded">
           {successMessage}
         </div>
       )}
-      
+
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Left Column - Available Metrics & Priorities */}
         <div className="lg:col-span-1">
@@ -402,61 +468,72 @@ const PicklistView: React.FC = () => {
               <label className="block font-medium mb-2">Your Team Number</label>
               <input
                 type="number"
-                value={yourTeamNumber || ''}
-                onChange={(e) => setYourTeamNumber(parseInt(e.target.value) || 0)}
+                value={yourTeamNumber || ""}
+                onChange={(e) =>
+                  setYourTeamNumber(parseInt(e.target.value) || 0)
+                }
                 placeholder="Enter your team number"
                 className="w-full p-2 border rounded"
               />
             </div>
           </div>
-          
+
           {/* Priorities Configuration */}
           <div className="bg-white rounded-lg shadow-md p-4 mb-6">
             <div className="flex border-b mb-4">
               <button
-                onClick={() => setActiveTab('first')}
+                onClick={() => setActiveTab("first")}
                 className={`py-2 px-4 font-medium ${
-                  activeTab === 'first'
-                    ? 'text-blue-600 border-b-2 border-blue-600'
-                    : 'text-gray-500 hover:text-gray-700'
+                  activeTab === "first"
+                    ? "text-blue-600 border-b-2 border-blue-600"
+                    : "text-gray-500 hover:text-gray-700"
                 }`}
               >
                 First Pick
               </button>
               <button
-                onClick={() => setActiveTab('second')}
+                onClick={() => setActiveTab("second")}
                 className={`py-2 px-4 font-medium ${
-                  activeTab === 'second'
-                    ? 'text-blue-600 border-b-2 border-blue-600'
-                    : 'text-gray-500 hover:text-gray-700'
+                  activeTab === "second"
+                    ? "text-blue-600 border-b-2 border-blue-600"
+                    : "text-gray-500 hover:text-gray-700"
                 }`}
               >
                 Second Pick
               </button>
               <button
-                onClick={() => setActiveTab('third')}
+                onClick={() => setActiveTab("third")}
                 className={`py-2 px-4 font-medium ${
-                  activeTab === 'third'
-                    ? 'text-blue-600 border-b-2 border-blue-600'
-                    : 'text-gray-500 hover:text-gray-700'
+                  activeTab === "third"
+                    ? "text-blue-600 border-b-2 border-blue-600"
+                    : "text-gray-500 hover:text-gray-700"
                 }`}
               >
                 Third Pick
               </button>
             </div>
-            
+
             <h2 className="text-lg font-bold mb-3">Current Priorities</h2>
-            
+
             {getActivePriorities().length === 0 ? (
-              <p className="text-gray-500 text-sm mb-4">No priorities selected. Add metrics from below.</p>
+              <p className="text-gray-500 text-sm mb-4">
+                No priorities selected. Add metrics from below.
+              </p>
             ) : (
               <div className="space-y-3 mb-4">
                 {getActivePriorities().map((priority) => {
-                  const metric = [...universalMetrics, ...gameMetrics].find(m => m.id === priority.id);
+                  const metric = [...universalMetrics, ...gameMetrics].find(
+                    (m) => m.id === priority.id,
+                  );
                   return (
-                    <div key={priority.id} className="p-2 bg-blue-50 border border-blue-200 rounded flex items-center">
+                    <div
+                      key={priority.id}
+                      className="p-2 bg-blue-50 border border-blue-200 rounded flex items-center"
+                    >
                       <div className="flex-1">
-                        <div className="font-medium">{metric?.label || priority.id}</div>
+                        <div className="font-medium">
+                          {metric?.label || priority.id}
+                        </div>
                         <div className="flex items-center">
                           <span className="text-sm mr-2">Weight:</span>
                           <input
@@ -465,10 +542,17 @@ const PicklistView: React.FC = () => {
                             max="3"
                             step="0.1"
                             value={priority.weight}
-                            onChange={(e) => handleWeightChange(priority.id, parseFloat(e.target.value))}
+                            onChange={(e) =>
+                              handleWeightChange(
+                                priority.id,
+                                parseFloat(e.target.value),
+                              )
+                            }
                             className="w-24"
                           />
-                          <span className="text-sm ml-2">{priority.weight.toFixed(1)}</span>
+                          <span className="text-sm ml-2">
+                            {priority.weight.toFixed(1)}
+                          </span>
                         </div>
                       </div>
                       <button
@@ -482,8 +566,10 @@ const PicklistView: React.FC = () => {
                 })}
               </div>
             )}
-            
-            <h3 className="font-semibold text-blue-700 mb-2">Universal Metrics</h3>
+
+            <h3 className="font-semibold text-blue-700 mb-2">
+              Universal Metrics
+            </h3>
             <div className="space-y-2 mb-4">
               {universalMetrics.map((metric) => (
                 <div
@@ -498,8 +584,10 @@ const PicklistView: React.FC = () => {
                 </div>
               ))}
             </div>
-            
-            <h3 className="font-semibold text-green-700 mb-2">Game-Specific Metrics</h3>
+
+            <h3 className="font-semibold text-green-700 mb-2">
+              Game-Specific Metrics
+            </h3>
             <div className="space-y-2">
               {gameMetrics.map((metric) => (
                 <div
@@ -516,38 +604,59 @@ const PicklistView: React.FC = () => {
             </div>
           </div>
         </div>
-        
+
         {/* Right Column - Picklist */}
         <div className="lg:col-span-2">
-          {activeTab === 'first' && (
+          {activeTab === "first" && (
             <PicklistGenerator
               datasetPath={datasetPath}
               yourTeamNumber={yourTeamNumber}
               pickPosition="first"
               priorities={firstPickPriorities}
-              onPicklistGenerated={(result) => handlePicklistGenerated('first', result)}
+              allPriorities={{
+                first: firstPickPriorities,
+                second: secondPickPriorities,
+                third: thirdPickPriorities,
+              }}
+              onPicklistGenerated={(result) =>
+                handlePicklistGenerated("first", result)
+              }
             />
           )}
-          
-          {activeTab === 'second' && (
+
+          {activeTab === "second" && (
             <PicklistGenerator
               datasetPath={datasetPath}
               yourTeamNumber={yourTeamNumber}
               pickPosition="second"
               priorities={secondPickPriorities}
+              allPriorities={{
+                first: firstPickPriorities,
+                second: secondPickPriorities,
+                third: thirdPickPriorities,
+              }}
               excludeTeams={excludedTeams}
-              onPicklistGenerated={(result) => handlePicklistGenerated('second', result)}
+              onPicklistGenerated={(result) =>
+                handlePicklistGenerated("second", result)
+              }
             />
           )}
-          
-          {activeTab === 'third' && (
+
+          {activeTab === "third" && (
             <PicklistGenerator
               datasetPath={datasetPath}
               yourTeamNumber={yourTeamNumber}
               pickPosition="third"
               priorities={thirdPickPriorities}
+              allPriorities={{
+                first: firstPickPriorities,
+                second: secondPickPriorities,
+                third: thirdPickPriorities,
+              }}
               excludeTeams={excludedTeams}
-              onPicklistGenerated={(result) => handlePicklistGenerated('third', result)}
+              onPicklistGenerated={(result) =>
+                handlePicklistGenerated("third", result)
+              }
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- create TeamComparison service and API route
- integrate new router in FastAPI
- add TeamComparisonModal component
- allow selecting teams to compare in PicklistGenerator
- wire comparison modal into PicklistView
- document new endpoint in CHANGELOG

## Testing
- `ruff check backend/app/api/team_comparison.py backend/app/services/team_comparison_service.py backend/app/main.py`
- `black backend/app/api/team_comparison.py backend/app/services/team_comparison_service.py backend/app/main.py`
- `npx prettier -w frontend/src/components/TeamComparisonModal.tsx frontend/src/components/PicklistGenerator.tsx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b301dcd4832380460e81164f0ea0