### PR TITLE
Fix Pydantic Field pattern usage

### DIFF
--- a/backend/app/api/team_comparison.py
+++ b/backend/app/api/team_comparison.py
@@ -20,7 +20,7 @@ class CompareTeamsRequest(BaseModel):
     unified_dataset_path: str
     team_numbers: List[int]
     your_team_number: int
-    pick_position: str = Field(..., regex="^(first|second|third)$")
+    pick_position: str = Field(..., pattern="^(first|second|third)$")
     priorities: List[MetricPriority]
     question: Optional[str] = None
 


### PR DESCRIPTION
## Summary
- use `pattern` instead of `regex` for pick_position validation

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `mypy backend/app/api/team_comparison.py` *(fails: Cannot find implementation or library stub for module named "app.services.team_comparison_service")*

------
https://chatgpt.com/codex/tasks/task_e_6841bc1f202c83238db760a7e62a13aa